### PR TITLE
Filter out projects without namespace

### DIFF
--- a/src/core/usecases/projectSelection.ts
+++ b/src/core/usecases/projectSelection.ts
@@ -68,7 +68,8 @@ export const privateThunks = {
                 selectedProjectId === null ||
                 !projects.map(({ id }) => id).includes(selectedProjectId)
             ) {
-                selectedProjectId = projects[0].id;
+                // TODO : handle case where there is no projects with namespace defined
+                selectedProjectId = projects.filter(p => p.namespace)[0].id;
 
                 await dispatch(
                     userConfigsThunks.changeValue({

--- a/src/ui/components/shared/Header.tsx
+++ b/src/ui/components/shared/Header.tsx
@@ -222,6 +222,7 @@ type ProjectSelectProps = {
     projects: {
         id: string;
         name: string;
+        namespace?: string;
     }[];
 };
 
@@ -249,11 +250,13 @@ const ProjectSelect = memo((props: ProjectSelectProps) => {
                 label="Project"
                 onChange={onChange}
             >
-                {projects.map(({ id, name }) => (
-                    <MenuItem key={id} value={id}>
-                        {name}
-                    </MenuItem>
-                ))}
+                {projects
+                    .filter(p => p.namespace)
+                    .map(({ id, name }) => (
+                        <MenuItem key={id} value={id}>
+                            {name}
+                        </MenuItem>
+                    ))}
             </Select>
         </FormControl>
     );


### PR DESCRIPTION
Work in progress : this PR filters out projects that have no namespace attached to it and use the first project with a namespace defined as the default selected project