### PR TITLE
Hide duplicate login button when logged out in home page

### DIFF
--- a/src/ui/components/pages/Home.tsx
+++ b/src/ui/components/pages/Home.tsx
@@ -18,7 +18,6 @@ import { getIsHomePageDisabled } from "ui/env";
 import { useConst } from "powerhooks/useConst";
 import { useStateRef } from "powerhooks/useStateRef";
 import { declareComponentKeys } from "i18nifty";
-import { useConstCallback } from "powerhooks/useConstCallback";
 
 Home.routeGroup = createGroup([routes.home]);
 
@@ -48,10 +47,6 @@ export function Home(props: Props) {
     const myBucketsLink = useMemo(() => routes.myBuckets().link, []);
     const catalogExplorerLink = useMemo(() => routes.catalogExplorer().link, []);
 
-    const onLoginClick = useConstCallback(() =>
-        userAuthentication.login({ "doesCurrentHrefRequiresAuth": false })
-    );
-
     return (
         <div className={cx(classes.root, className)}>
             <div className={classes.hero}>
@@ -67,9 +62,7 @@ export function Home(props: Props) {
                     <Text typo="subtitle" className={classes.heroSubtitle}>
                         {t("subtitle")}
                     </Text>
-                    {!isUserLoggedIn ? (
-                        <Button onClick={onLoginClick}>{t("login")}</Button>
-                    ) : (
+                    {isUserLoggedIn && (
                         <Button href="https://docs.sspcloud.fr/">{t("new user")}</Button>
                     )}
                 </div>


### PR DESCRIPTION
Fixes: #447 

## Summary

As discussed in the issue, this PR hides the duplicate login button when the user is not logged in.

Then, when logged, the button linking to the docs appears.

The `Home` component is not used elsewhere, so it is safe to remove login from this component (since the `Header` component that is on the same view as `Home` gives this possibility)