### PR TITLE
Add support for istio with option to specify gateways

### DIFF
--- a/src/core/adapters/onyxiaApi.ts
+++ b/src/core/adapters/onyxiaApi.ts
@@ -151,7 +151,12 @@ export function createOnyxiaApi(params: {
                                 ingressClassName: string;
                                 ingress?: boolean;
                                 route?: boolean;
-                                istio?: boolean;
+                                istio?:
+                                    | {
+                                          enabled: boolean;
+                                          gateways: string[];
+                                      }
+                                    | undefined;
                             };
                             defaultConfiguration?: {
                                 ipprotection?: boolean;

--- a/src/core/ports/OnyxiaApi.ts
+++ b/src/core/ports/OnyxiaApi.ts
@@ -70,7 +70,12 @@ export type DeploymentRegion = {
     ingressClassName: string | undefined;
     ingress: boolean | undefined;
     route: boolean | undefined;
-    istio: boolean | undefined;
+    istio:
+        | {
+              enabled: boolean;
+              gateways: string[];
+          }
+        | undefined;
     initScriptUrl: string;
     s3: DeploymentRegion.S3 | undefined;
     allowedURIPatternForUserDefinedInitScript: string;
@@ -284,7 +289,12 @@ export type OnyxiaValues = {
         ingressClassName: string | undefined;
         ingress: boolean | undefined;
         route: boolean | undefined;
-        istio: boolean | undefined;
+        istio:
+            | {
+                  enabled: boolean;
+                  gateways: string[];
+              }
+            | undefined;
         randomSubdomain: string;
         initScriptUrl: string;
     };


### PR DESCRIPTION
Previously Istio was defined as a boolean to be enabled or not. This was limiting, since Istio has concept of how the request should be routed (via their Gateway resource, ref doc https://istio.io/latest/docs/reference/config/networking/gateway/). Thus gateways should be able to be specified. 

This change is related to https://github.com/InseeFrLab/onyxia-api/pull/242