### PR TITLE
Rename training button to "tutorials"

### DIFF
--- a/src/ui/i18n/resources/en.tsx
+++ b/src/ui/i18n/resources/en.tsx
@@ -271,7 +271,7 @@ export const translations: Translations<"en"> = {
     "Header": {
         "login": "Login",
         "logout": "Logout",
-        "trainings": "Trainings",
+        "trainings": "Tutorials",
         "documentation": "Documentation",
         "project": "Project"
     },

--- a/src/ui/i18n/resources/fr.tsx
+++ b/src/ui/i18n/resources/fr.tsx
@@ -272,7 +272,7 @@ export const translations: Translations<"fr"> = {
     "Header": {
         "login": "Connexion",
         "logout": "Déconnexion",
-        "trainings": "Formations",
+        "trainings": "Tutoriels",
         "documentation": "Documentation",
         "project": "Projet"
     },


### PR DESCRIPTION
As the documentation moved to the training section, I suggest we rename it "Tutorials/tutoriels" instead of "Formations/formation" to better encompass the whole content of the page