### PR TITLE
Add support for istio ingress with new structure

### DIFF
--- a/src/core/adapters/onyxiaApi.ts
+++ b/src/core/adapters/onyxiaApi.ts
@@ -87,7 +87,12 @@ export function createOnyxiaApi(params: {
                                 ingressClassName: string;
                                 ingress?: boolean;
                                 route?: boolean;
-                                istio?: boolean;
+                                istio?:
+                                    | {
+                                          enabled: boolean;
+                                          gateways: string[];
+                                      }
+                                    | undefined;
                             };
                             defaultConfiguration?: {
                                 ipprotection?: boolean;

--- a/src/core/ports/OnyxiaApi.ts
+++ b/src/core/ports/OnyxiaApi.ts
@@ -81,7 +81,12 @@ export type DeploymentRegion = {
     ingressClassName: string | undefined;
     ingress: boolean | undefined;
     route: boolean | undefined;
-    istio: boolean | undefined;
+    istio:
+        | {
+              enabled: boolean;
+              gateways: string[];
+          }
+        | undefined;
     initScriptUrl: string;
     s3: DeploymentRegion.S3 | undefined;
     allowedURIPatternForUserDefinedInitScript: string;
@@ -297,7 +302,12 @@ export type OnyxiaValues = {
         ingressClassName: string | undefined;
         ingress: boolean | undefined;
         route: boolean | undefined;
-        istio: boolean | undefined;
+        istio:
+            | {
+                  enabled: boolean;
+                  gateways: string[];
+              }
+            | undefined;
         randomSubdomain: string;
         initScriptUrl: string;
     };


### PR DESCRIPTION
This change is related to https://github.com/InseeFrLab/onyxia-api/pull/242 , which has been merged and is a part of release [onyxia-api v0.29](https://github.com/InseeFrLab/onyxia-api/releases/tag/v0.29)

Previously Istio was defined as a boolean to be enabled or not. This was limiting, since Istio decide how the request should be routed (via their Gateway resource, ref doc https://istio.io/latest/docs/reference/config/networking/gateway/).

(this PR was originally #555 , but is opened as new PR due to new fork )

