### PR TITLE
Add env variable which controls if auto launch is enabled or not

### DIFF
--- a/.env
+++ b/.env
@@ -118,4 +118,6 @@ REACT_APP_EXTRA_LEFTBAR_ITEMS=
 REACT_APP_HEADER_LINKS=
 
 # Description used in the preview card for social media: https://user-images.githubusercontent.com/6702424/152668805-d1e055e0-2d9d-4b6c-9bc7-fba0093855aa.png
-REACT_APP_DESCRIPTION=Data science oriented container launcher 
+REACT_APP_DESCRIPTION=Data science oriented container launcher
+
+REACT_APP_DISABLE_AUTO_LAUNCH=false

--- a/src/ui/env.ts
+++ b/src/ui/env.ts
@@ -69,6 +69,21 @@ export const getIsHomePageDisabled = memoize((): boolean => {
     return DISABLE_HOME_PAGE === "true";
 });
 
+export const getIsAutoLaunchDisabled = memoize((): boolean => {
+    const { DISABLE_AUTO_LAUNCH } = getEnv();
+
+    const possibleValues = ["true", "false"];
+
+    assert(
+        possibleValues.indexOf(DISABLE_AUTO_LAUNCH) >= 0,
+        `${symToStr({ DISABLE_AUTO_LAUNCH })} should either be ${possibleValues.join(
+            " or "
+        )}`
+    );
+
+    return DISABLE_AUTO_LAUNCH === "true";
+});
+
 export const getDoHideOnyxia = memoize((): boolean => {
     const { HEADER_HIDE_ONYXIA } = getEnv();
 

--- a/src/ui/pages/catalog/CatalogLauncher/CatalogLauncher.tsx
+++ b/src/ui/pages/catalog/CatalogLauncher/CatalogLauncher.tsx
@@ -23,6 +23,7 @@ import type { UnpackEvt } from "evt";
 import { Markdown } from "onyxia-ui/Markdown";
 import { declareComponentKeys } from "i18nifty";
 import { symToStr } from "tsafe/symToStr";
+import { getIsAutoLaunchDisabled } from "../../../env";
 
 export type Props = {
     className?: string;
@@ -178,7 +179,8 @@ export const CatalogLauncher = memo((props: Props) => {
             case "ready":
                 switch (state.launchState) {
                     case "not launching":
-                        if (route.params.autoLaunch) {
+                        const autoLaunchEnabled = !getIsAutoLaunchDisabled();
+                        if (autoLaunchEnabled && route.params.autoLaunch) {
                             const { sensitiveConfigurations } = state;
 
                             if (sensitiveConfigurations.length !== 0) {


### PR DESCRIPTION
Keep old behaviour of allowing auto launch by default.


The user will land at the service launcher if the URL specifies autoLaunch=true when auto launch is disabled, as shown in this video:


https://github.com/InseeFrLab/onyxia-web/assets/10381866/37c642bf-11c3-4d8f-ab59-e01233732f5c



Discussion: Should the user get an alert or a notification that the service tried to auto launch but failed to due the configuration of onyxia-web? I vote no. One reason is there are no need for the user to have a concept of "autolaunch" and whenever or not the autoLaunch "fail".


Closes #548