### PR TITLE
A Kubernetes PriorityClassName can be set for onyxia web and api

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.2.0
+version: 4.2.1

--- a/helm-chart/templates/deployment-api.yaml
+++ b/helm-chart/templates/deployment-api.yaml
@@ -71,3 +71,6 @@ spec:
     {{- if .Values.api.extraVolumes }}
       volumes: {{- toYaml .Values.api.extraVolumes | nindent 6 }}
     {{- end }}
+    {{- if .Values.api.priorityClassName }}
+      priorityClassName: "{{ .Values.api.priorityClassName }}"
+    {{- end }}

--- a/helm-chart/templates/deployment-web.yaml
+++ b/helm-chart/templates/deployment-web.yaml
@@ -69,3 +69,6 @@ spec:
     {{- if .Values.web.extraVolumes }}
       volumes: {{- toYaml .Values.web.extraVolumes | nindent 6 }}
     {{- end }}
+    {{- if .Values.web.priorityClassName }}
+      priorityClassName: "{{ .Values.web.priorityClassName }}"
+    {{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -50,6 +50,12 @@ web:
     repository: inseefrlab/onyxia-web
     tag: 2.29.7
     pullPolicy: IfNotPresent
+
+  ## Pod priority settings
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  priorityClassName: ""
+
   podLabels: {}
   podSecurityContext: {} # fsGroup: 2000
   securityContext:
@@ -92,6 +98,12 @@ api:
     tag: v0.31
     pullPolicy: IfNotPresent
   contextPath: /api
+
+  ## Pod priority settings
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  ##
+  priorityClassName: ""
+
   podLabels: {}
   podSecurityContext: {} # fsGroup: 2000
   securityContext:


### PR DESCRIPTION
Hello,

I already did those changes on [this pull request](https://github.com/InseeFrLab/helm-charts/pull/55) but just realize that the repository has recently been replaced by this one.
It's just a way to configure a "priorityClassName" (ref: [https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)) on onyxia-web and onyxia-api. It could be useful to prevent the according pods from being deleted by Kubernetes scheduler.

I didn't bump the Chart version.

Let me know if it's sound relevant to you and/or if I missed something.