### PR TITLE
Fix mismatch between helm chart in configuration and launch, v1

### DIFF
--- a/web/src/core/ports/OnyxiaApi/OnyxiaApi.ts
+++ b/web/src/core/ports/OnyxiaApi/OnyxiaApi.ts
@@ -35,17 +35,23 @@ export type OnyxiaApi = {
         clear: () => void;
     };
 
-    getPackageConfig: (params: { catalogId: string; packageName: string }) => Promise<{
+    getPackageConfig: (params: {
+        catalogId: string;
+        packageName: string;
+        isDevModeEnabled: boolean;
+    }) => Promise<{
         getValuesSchemaJson: (params: {
             xOnyxiaContext: XOnyxiaContext;
         }) => JSONSchemaObject;
         dependencies: string[];
         sources: string[];
+        packageVersion: string;
     }>;
 
     launchPackage: (params: {
         catalogId: string;
         packageName: string;
+        packageVersion: string;
         options: Record<string, unknown>;
     }) => Promise<void>;
 

--- a/web/src/core/usecases/launcher/state.ts
+++ b/web/src/core/usecases/launcher/state.ts
@@ -20,6 +20,7 @@ export declare namespace State {
         catalogId: string;
         catalogLocation: string;
         packageName: string;
+        packageVersion: string;
         sources: string[];
         pathOfFormFieldsWhoseValuesAreDifferentFromDefault: {
             path: string[];
@@ -60,6 +61,7 @@ export const { reducer, actions } = createSlice({
                         catalogLocation: string;
                         catalogId: string;
                         packageName: string;
+                        packageVersion: string;
                         icon: string | undefined;
                         sources: string[];
                         formFields: State.Ready["formFields"];
@@ -75,6 +77,7 @@ export const { reducer, actions } = createSlice({
                     catalogLocation,
                     catalogId,
                     packageName,
+                    packageVersion,
                     icon,
                     sources,
                     formFields,
@@ -91,6 +94,7 @@ export const { reducer, actions } = createSlice({
                         catalogId,
                         catalogLocation,
                         packageName,
+                        packageVersion,
                         icon,
                         sources,
                         formFields,

--- a/web/src/core/usecases/launcher/thunks.ts
+++ b/web/src/core/usecases/launcher/thunks.ts
@@ -51,11 +51,13 @@ export const thunks = {
             );
 
             dispatch(actions.initializationStarted());
+            const { isDevModeEnabled } = userConfigsSelectors.userConfigs(getState());
 
-            const { dependencies, sources, getValuesSchemaJson } =
+            const { dependencies, sources, packageVersion, getValuesSchemaJson } =
                 await onyxiaApi.getPackageConfig({
                     catalogId,
-                    packageName
+                    packageName,
+                    isDevModeEnabled
                 });
 
             {
@@ -603,6 +605,7 @@ export const thunks = {
                     catalogLocation,
                     icon,
                     packageName,
+                    packageVersion,
                     sources,
                     formFields,
                     infosAboutWhenFieldsShouldBeHidden,
@@ -662,6 +665,7 @@ export const thunks = {
             await onyxiaApi.launchPackage({
                 "catalogId": state.catalogId,
                 "packageName": state.packageName,
+                "packageVersion": state.packageVersion,
                 "options": formFieldsValueToObject(state.formFields)
             });
 


### PR DESCRIPTION
See #623

In this first iteration of a fix the following has been implemented:
If devMode is enabled the latest version will be used (i.e. the first element in the list), if not the newest stable version (or first available if no stable version) will be used.

With other words: there are no way of controlling version the version in the GUI, but at least we have consistency between web and api when launching a service.  

