### PR TITLE
Fix missing backslash on helper command for setting kubernetes context

### DIFF
--- a/web/src/core/usecases/k8sCredentials.ts
+++ b/web/src/core/usecases/k8sCredentials.ts
@@ -212,7 +212,7 @@ export const selectors = (() => {
                 `  --auth-provider-arg=refresh-token=${state.refreshToken} \\`,
                 `  --auth-provider-arg=id-token=${state.idToken}`,
                 ``,
-                `kubectl config set-context ${host}`,
+                `kubectl config set-context ${host} \\`,
                 `  --user=${state.user} \\`,
                 `  --cluster=${host} \\`,
                 `  --namespace=${namespace}`,


### PR DESCRIPTION
Hi, 

Nothing much to say. Title is self explanatory. 😉