### PR TITLE
Add support for regions customValues

### DIFF
--- a/web/src/core/adapters/onyxiaApi/default.ts
+++ b/web/src/core/adapters/onyxiaApi/default.ts
@@ -82,6 +82,7 @@ export function createOnyxiaApi(params: {
                         id: string;
                         services: {
                             allowedURIPattern: string;
+                            customValues?: Record<string, unknown>;
                             expose: {
                                 domain: string;
                                 ingressClassName: string;
@@ -319,6 +320,7 @@ export function createOnyxiaApi(params: {
                                 region.packageRepositoryInjection,
                             "certificateAuthorityInjection":
                                 region.certificateAuthorityInjection,
+                            "customValues": region.services.customValues,
                             "kubernetes": (() => {
                                 const { k8sPublicEndpoint } = region.services;
                                 return k8sPublicEndpoint?.URL === undefined

--- a/web/src/core/adapters/onyxiaApi/mock.ts
+++ b/web/src/core/adapters/onyxiaApi/mock.ts
@@ -33,6 +33,7 @@ export const onyxiaApi: OnyxiaApi = {
                         "ingress": true,
                         "route": undefined,
                         "istio": undefined,
+                        "customValues": undefined,
                         "initScriptUrl":
                             "https://InseeFrLab.github.io/onyxia/onyxia-init.sh",
                         "s3": undefined,

--- a/web/src/core/ports/OnyxiaApi/DeploymentRegion.ts
+++ b/web/src/core/ports/OnyxiaApi/DeploymentRegion.ts
@@ -7,6 +7,7 @@ export type DeploymentRegion = {
     ingressClassName: string | undefined;
     ingress: boolean | undefined;
     route: boolean | undefined;
+    customValues: Record<string, unknown> | undefined;
     istio:
         | {
               enabled: boolean;

--- a/web/src/core/ports/OnyxiaApi/XOnyxia.ts
+++ b/web/src/core/ports/OnyxiaApi/XOnyxia.ts
@@ -64,6 +64,7 @@ export type XOnyxiaContext = {
         defaultIpProtection: boolean | undefined;
         defaultNetworkPolicy: boolean | undefined;
         allowedURIPattern: string;
+        customValues: Record<string, unknown> | undefined;
         kafka:
             | {
                   url: string;

--- a/web/src/core/usecases/launcher/thunks.ts
+++ b/web/src/core/usecases/launcher/thunks.ts
@@ -278,6 +278,7 @@ export const thunks = {
                             "defaultNetworkPolicy": region.defaultNetworkPolicy,
                             "allowedURIPattern":
                                 region.allowedURIPatternForUserDefinedInitScript,
+                            "customValues": region.customValues ?? {},
                             "kafka": region.kafka,
                             "from": region.from,
                             "tolerations": region.tolerations,


### PR DESCRIPTION
Custom values can be defined in onyxia-api. This feature was introduced in onyxia-api in PR  https://github.com/InseeFrLab/onyxia-api/pull/298 .
This PR does such that these values can be used in the helm templates. They will be available as region.customValues.<my-key> in helm templates.
