### PR TITLE
Add support for oidc extra params from api

### DIFF
--- a/web/src/core/adapters/oidc/default.ts
+++ b/web/src/core/adapters/oidc/default.ts
@@ -5,12 +5,14 @@ export async function createOidc(params: {
     issuerUri: string;
     clientId: string;
     transformUrlBeforeRedirect: (url: string) => string;
+    extraQueryParams?: Record<string, string>;
 }): Promise<Oidc> {
-    const { issuerUri, clientId, transformUrlBeforeRedirect } = params;
+    const { issuerUri, clientId, transformUrlBeforeRedirect, extraQueryParams } = params;
 
     return createOidcSpa({
         issuerUri,
         clientId,
-        transformUrlBeforeRedirect
+        transformUrlBeforeRedirect,
+        extraQueryParams
     });
 }

--- a/web/src/core/adapters/oidc/utils/createOidcOrFallback.ts
+++ b/web/src/core/adapters/oidc/utils/createOidcOrFallback.ts
@@ -8,6 +8,7 @@ export async function createOidcOrFallback(params: {
         | {
               issuerUri?: string;
               clientId: string;
+              extraParams?: Record<string, string>;
           }
         | undefined;
     fallbackOidc: Oidc.LoggedIn | undefined;
@@ -16,7 +17,7 @@ export async function createOidcOrFallback(params: {
         params;
 
     const wrap = (() => {
-        const { issuerUri, clientId } = {
+        const { issuerUri, clientId, extraParams } = {
             ...fallbackOidc?.params,
             ...noUndefined(oidcParams ?? {})
         };
@@ -39,7 +40,7 @@ export async function createOidcOrFallback(params: {
 
         return {
             "type": "oidc params",
-            "oidcParams": { issuerUri, clientId }
+            "oidcParams": { issuerUri, clientId, extraParams }
         } as const;
     })();
 
@@ -56,7 +57,8 @@ export async function createOidcOrFallback(params: {
             const oidc = await createOidc({
                 "issuerUri": wrap.oidcParams.issuerUri,
                 "clientId": wrap.oidcParams.clientId,
-                "transformUrlBeforeRedirect": url => url
+                "transformUrlBeforeRedirect": url => url,
+                "extraQueryParams": wrap.oidcParams.extraParams
             });
 
             if (!oidc.isUserLoggedIn) {

--- a/web/src/core/adapters/onyxiaApi/default/ApiTypes.ts
+++ b/web/src/core/adapters/onyxiaApi/default/ApiTypes.ts
@@ -145,6 +145,7 @@ export type ApiTypes = {
         oidcConfiguration?: {
             issuerURI: string;
             clientID: string;
+            extraParams: Record<string, string>;
         };
     };
     "/public/catalogs": {

--- a/web/src/core/adapters/onyxiaApi/default/default.ts
+++ b/web/src/core/adapters/onyxiaApi/default/default.ts
@@ -80,7 +80,8 @@ export function createOnyxiaApi(params: {
                         ? undefined
                         : {
                               "issuerUri": data.oidcConfiguration.issuerURI,
-                              "clientId": data.oidcConfiguration.clientID
+                              "clientId": data.oidcConfiguration.clientID,
+                              "extraParams": data.oidcConfiguration.extraParams
                           };
 
                 const regions = data.regions.map(

--- a/web/src/core/bootstrap.ts
+++ b/web/src/core/bootstrap.ts
@@ -120,7 +120,8 @@ export async function bootstrapCore(
         return createOidc({
             "issuerUri": oidcParams.issuerUri,
             "clientId": oidcParams.clientId,
-            "transformUrlBeforeRedirect": transformUrlBeforeRedirectToLogin
+            "transformUrlBeforeRedirect": transformUrlBeforeRedirectToLogin,
+            "extraQueryParams": oidcParams.extraParams
         });
     })();
 

--- a/web/src/core/ports/Oidc.ts
+++ b/web/src/core/ports/Oidc.ts
@@ -5,6 +5,7 @@ export declare namespace Oidc {
         params: {
             issuerUri: string;
             clientId: string;
+            extraParams?: Record<string, string>;
         };
     };
 

--- a/web/src/core/ports/OnyxiaApi/DeploymentRegion.ts
+++ b/web/src/core/ports/OnyxiaApi/DeploymentRegion.ts
@@ -70,6 +70,7 @@ export type DeploymentRegion = {
                   | {
                         issuerUri?: string;
                         clientId: string;
+                        extraParams?: Record<string, string>;
                     }
                   | undefined;
           }

--- a/web/src/core/ports/OnyxiaApi/OnyxiaApi.ts
+++ b/web/src/core/ports/OnyxiaApi/OnyxiaApi.ts
@@ -15,6 +15,7 @@ export type OnyxiaApi = {
                 | {
                       issuerUri: string;
                       clientId: string;
+                      extraParams: Record<string, string>;
                   }
                 | undefined;
         }>;


### PR DESCRIPTION
In some use cases the user want to specify extra query parameters. E.g. prompt type. This can now be done by specifying the parameters in the API. The frontend will use those parameters and send it along in the oidc flow.

Draft PR for visibility until code is ready for review.