### PR TITLE
Allow S3 public bucket configuration in project settings

### DIFF
--- a/web/src/core/adapters/s3Client/default.ts
+++ b/web/src/core/adapters/s3Client/default.ts
@@ -196,17 +196,32 @@ export function createS3Client(params: ParamsOfCreateS3Client): S3Client {
                         "awsS3Client": cachedAwsS3Client
                     };
                 }
-
-                const awsS3Client = new ns_aws_sdk_client_s3.S3Client({
+                let awsS3ClientConfiguration = {
                     "region": params.region ?? "us-east-1",
-                    "credentials": {
-                        "accessKeyId": tokens.accessKeyId,
-                        "secretAccessKey": tokens.secretAccessKey,
-                        "sessionToken": tokens.sessionToken
-                    },
                     "endpoint": params.url,
                     "forcePathStyle": params.pathStyleAccess
-                });
+                };
+                let awsS3Client: ns_aws_sdk_client_s3.S3Client;
+                if (
+                    tokens.accessKeyId === undefined ||
+                    tokens.secretAccessKey === undefined
+                ) {
+                    awsS3Client = new ns_aws_sdk_client_s3.S3Client(
+                        Object.assign(awsS3ClientConfiguration, {
+                            "signer": { sign: async (request: any) => request }
+                        })
+                    );
+                } else {
+                    awsS3Client = new ns_aws_sdk_client_s3.S3Client(
+                        Object.assign(awsS3ClientConfiguration, {
+                            "credentials": {
+                                "accessKeyId": tokens.accessKeyId,
+                                "secretAccessKey": tokens.secretAccessKey,
+                                "sessionToken": tokens.sessionToken
+                            }
+                        })
+                    );
+                }
 
                 awsS3ClientByTokens.set(tokens, awsS3Client);
 

--- a/web/src/core/usecases/s3ConfigCreation/selectors.ts
+++ b/web/src/core/usecases/s3ConfigCreation/selectors.ts
@@ -56,9 +56,7 @@ const formValuesErrors = createSelector(formValues, formValues => {
                     !(
                         key === "url" ||
                         key === "workingDirectoryPath" ||
-                        key === "accountFriendlyName" ||
-                        key === "accessKeyId" ||
-                        key === "secretAccessKey"
+                        key === "accountFriendlyName"
                     )
                 ) {
                     break empty_required_field;
@@ -134,8 +132,8 @@ export const submittableFormValues = createSelector(
                     .replace(/\/*$/g, "") + "/", // Enforce trailing slash
             "pathStyleAccess": formValues.pathStyleAccess,
             "accountFriendlyName": formValues.accountFriendlyName.trim(),
-            "accessKeyId": formValues.accessKeyId.trim(),
-            "secretAccessKey": formValues.secretAccessKey.trim(),
+            "accessKeyId": formValues.accessKeyId?.trim(),
+            "secretAccessKey": formValues.secretAccessKey?.trim(),
             "sessionToken": formValues.sessionToken?.trim()
         };
     }

--- a/web/src/ui/pages/projectSettings/ProjectSettingsS3ConfigTab/S3ConfigDialogs/AddCustomS3ConfigDialog.tsx
+++ b/web/src/ui/pages/projectSettings/ProjectSettingsS3ConfigTab/S3ConfigDialogs/AddCustomS3ConfigDialog.tsx
@@ -288,12 +288,12 @@ const Body = memo(() => {
                             ? undefined
                             : t(formValuesErrors.accessKeyId)
                     }
-                    defaultValue={formValues.accessKeyId}
+                    defaultValue={formValues.accessKeyId ?? ""}
                     doOnlyShowErrorAfterFirstFocusLost
                     onValueBeingTypedChange={({ value }) =>
                         s3ConfigCreation.changeValue({
                             "key": "accessKeyId",
-                            value
+                            "value": value || undefined
                         })
                     }
                 />
@@ -309,12 +309,12 @@ const Body = memo(() => {
                             ? undefined
                             : t(formValuesErrors.secretAccessKey)
                     }
-                    defaultValue={formValues.secretAccessKey}
+                    defaultValue={formValues.secretAccessKey ?? ""}
                     doOnlyShowErrorAfterFirstFocusLost
                     onValueBeingTypedChange={({ value }) =>
                         s3ConfigCreation.changeValue({
                             "key": "secretAccessKey",
-                            value
+                            "value": value || undefined
                         })
                     }
                 />


### PR DESCRIPTION
I think we already discussed that with you but we would like to configure a public bucket on the project settings (without giving access key id and secret).

I found [this workaround](https://github.com/aws/aws-sdk-js-v3/issues/2321#issuecomment-916336230) on an issue in the aws-sdk library to send an anonymous request. I tried it and it works on my side on a public bucket we have.

Could you please take a look at this PR and let me know.

Thx