### PR TITLE
Fix fuzzy text when command bar is expanded by removing borderRadius

### DIFF
--- a/web/src/ui/shared/CommandBar.tsx
+++ b/web/src/ui/shared/CommandBar.tsx
@@ -279,7 +279,6 @@ const useStyles = tss
                 },
                 "transform": "scaleY(1)",
                 "transformOrigin": "top",
-                borderRadius,
                 "paddingTop": theme.spacing(2),
                 // Only work on Firefox when writing this
                 // Note this spec isn't great, we can't specify the hover color...


### PR DESCRIPTION
Hi, 

On chrome, the text is fuzzy when the command bar is expanded.
I don't know why, but removing the borderRadius resolves the issue...
I didn't found a way to keep the bottom left radius...