### PR TITLE
fix norwegian translation: Add missing whitespace

### DIFF
--- a/web/src/ui/i18n/resources/no.tsx
+++ b/web/src/ui/i18n/resources/no.tsx
@@ -541,7 +541,7 @@ export const translations: Translations<"no"> = {
                     <MaybeLink href={sourceUrls.helmChartSourceUrl}>
                         {helmChartName}
                     </MaybeLink>
-                }
+                }{" "}
                 fra tjenestekatalogen{" "}
                 {
                     <MaybeLink href={sourceUrls.helmChartRepositorySourceUrl}>


### PR DESCRIPTION
Fix a missing whitespace


Before:
<img width="805" alt="image" src="https://github.com/user-attachments/assets/2c0a7bdd-ffcf-402d-8283-1a6d68a369d6">
