### PR TITLE
Fix missing import in python snippet 

### DIFF
--- a/web/src/core/usecases/s3CodeSnippets.ts
+++ b/web/src/core/usecases/s3CodeSnippets.ts
@@ -274,6 +274,7 @@ minio$list_buckets()
 						`;
                         case "Python (s3fs)":
                             return `
+import os
 import s3fs
 os.environ["AWS_ACCESS_KEY_ID"] = '${credentials.AWS_ACCESS_KEY_ID}'
 os.environ["AWS_SECRET_ACCESS_KEY"] = '${credentials.AWS_SECRET_ACCESS_KEY}'


### PR DESCRIPTION
Just a quick fix of a missing python import in a snippet of code that allows to connect to personal bucket storage.