### PR TITLE
Add proxyInjection.enabled to XOnyxiaParams

### DIFF
--- a/web/src/core/ports/OnyxiaApi/XOnyxia.ts
+++ b/web/src/core/ports/OnyxiaApi/XOnyxia.ts
@@ -175,6 +175,7 @@ export type XOnyxiaContext = {
     };
     proxyInjection:
         | {
+              enabled: boolean | undefined;
               httpProxyUrl: string | undefined;
               httpsProxyUrl: string | undefined;
               noProxy: string | undefined;


### PR DESCRIPTION
The helm-charts recently changed to test `proxyInjection.enabled` instead of `proxyInjection` (see https://github.com/InseeFrLab/helm-charts-interactive-services/commit/54f219505ddd37717e35b988daea46f9195f9d54 for instance), so it would be convenient to allow injecting this. Right now, we need to have hard-coded values in our `values.schema.json` file just for this "enabled" flag, while our other proxy settings can be defined in your region config.

Not familiar with the onyxia codebase though, so the changes I made might be insufficient to achieve what I'm expecting - please mention any relevant changes I should address.

I'll also open a PR for [the doc](https://docs.onyxia.sh/admin-doc/catalog-of-services#x-onyxia-overwritedefaultwith) with the same addition shortly. 