### PR TITLE
Hide terms link if no terms are provided

### DIFF
--- a/web/src/ui/App/Footer.tsx
+++ b/web/src/ui/App/Footer.tsx
@@ -51,11 +51,13 @@ export const Footer = memo((props: Props) => {
                     changeLanguageText={t("change language")}
                 />
             )}
-            {spacing}
-            <a {...routes.terms().link}>
-                {" "}
-                <Text typo="body 2">{t("terms of service")}</Text>{" "}
-            </a>
+            {env.TERMS_OF_SERVICES !== undefined && spacing}
+            {env.TERMS_OF_SERVICES !== undefined && (
+                <a {...routes.terms().link}>
+                    {" "}
+                    <Text typo="body 2">{t("terms of service")}</Text>{" "}
+                </a>
+            )}
             {spacing}
             {env.ONYXIA_VERSION !== undefined && (
                 <a href={env.ONYXIA_VERSION_URL} target="_blank" rel="noreferrer">


### PR DESCRIPTION
Terms and condition link should not be displayed if no terms are privded by the user.
Also make sure to not add extra spacing