### PR TITLE
Do not cause rerender when fromNowText has not changed

### DIFF
--- a/web/src/ui/shared/formattedDate/useFormattedDate.ts
+++ b/web/src/ui/shared/formattedDate/useFormattedDate.ts
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useReducer } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { useLang } from "ui/i18n";
 import { getFormattedDate } from "./getFormattedDate";
 import { fromNow } from "./dateTimeFormatter";
@@ -15,23 +15,27 @@ export function useFormattedDate(params: { time: number }): string {
 export function useFromNow(params: { dateTime: number }) {
     const { dateTime } = params;
 
-    const [trigger, forceUpdate] = useReducer(n => n + 1, 0);
-
-    useEffect(() => {
-        const timer = setInterval(() => forceUpdate(), 1000);
-
-        return () => {
-            clearTimeout(timer);
-        };
-    }, []);
-
     const { lang } = useLang();
 
-    const fromNowText = useMemo(
-        () => fromNow({ dateTime }),
+    const [fromNowText, setFromNowText] = useState(() => fromNow({ dateTime }));
 
-        [lang, trigger, dateTime]
-    );
+    useEffect(() => {
+        const updateText = () => {
+            const newText = fromNow({ dateTime });
+
+            if (fromNowText !== newText) {
+                setFromNowText(newText);
+            }
+        };
+
+        updateText();
+
+        const timer = setInterval(updateText, 1000);
+
+        return () => {
+            clearInterval(timer);
+        };
+    }, [dateTime, lang]);
 
     return { fromNowText };
 }


### PR DESCRIPTION
There was a re-render of the entire component using `useFromNow` every second. To test this, you can simply add a `console.log("render")` in a component that uses `useFromNow` (e.g., MyServicesRunningTime). You will notice a render logged in the console every second.

With this fix, the component will re-render only when the value returned by the hook changes.