### PR TITLE
Fix number regex for negative number

### DIFF
--- a/web/src/ui/pages/launcher/RootFormComponent/formFields/NumberFormField.tsx
+++ b/web/src/ui/pages/launcher/RootFormComponent/formFields/NumberFormField.tsx
@@ -41,7 +41,7 @@ export const NumberFormField = memo((props: Props) => {
                 throttleDelay: 500,
                 onChange,
                 parse: serializedValue => {
-                    if (!/^[0-9.]+$/.test(serializedValue)) {
+                    if (!/^-?[0-9.]+$/.test(serializedValue)) {
                         console.log("not a number");
                         return {
                             isValid: false,


### PR DESCRIPTION
When validating user values against  the `values.schema.json`, the number regex is only validating positive values.