### PR TITLE
Check for slice kind to set the `catalogs` API environment variable in Helm Chart

### DIFF
--- a/helm-chart/templates/configmap.yaml
+++ b/helm-chart/templates/configmap.yaml
@@ -17,10 +17,10 @@ data:
 {{- if .Values.api.regions }}
   regions: {{ .Values.api.regions | toJson | quote }}
 {{- end}}
-{{- if .Values.api.catalogs }}
+{{- if kindIs "slice" (.Values.api).catalogs }}
   catalogs: {{ .Values.api.catalogs | toJson | quote }}
-{{- end}}
+{{- end }}
 {{- if .Values.api.schemas.enabled }}
   external.schema.directory: {{ printf "%s%s/" .Values.api.schemas.rootPath .Values.api.schemas.subPathDefault | quote }}
   role.schema.directory: {{ printf "%s%s/" .Values.api.schemas.rootPath .Values.api.schemas.subPathRole | quote }}
-{{- end}}
+{{- end }}


### PR DESCRIPTION
Fixes #1001