### PR TITLE
feat: add unit fallback when we bulkdelete

### DIFF
--- a/web/src/core/adapters/s3Client/s3Client.ts
+++ b/web/src/core/adapters/s3Client/s3Client.ts
@@ -606,19 +606,18 @@ export function createS3Client(
 
             const { awsS3Client } = await getAwsS3Client();
 
+            const { DeleteObjectsCommand } = await import("@aws-sdk/client-s3");
+
+            const objects = paths.map(path => {
+                const { objectName } = bucketNameAndObjectNameFromS3Path(path);
+                return { Key: objectName };
+            });
+
             try {
                 await awsS3Client.send(
-                    new (await import("@aws-sdk/client-s3")).DeleteObjectsCommand({
+                    new DeleteObjectsCommand({
                         Bucket: bucketName,
-                        Delete: {
-                            Objects: paths.map(path => {
-                                const { objectName } =
-                                    bucketNameAndObjectNameFromS3Path(path);
-                                return {
-                                    Key: objectName
-                                };
-                            })
-                        }
+                        Delete: { Objects: objects }
                     })
                 );
             } catch (err) {

--- a/web/src/core/adapters/s3Client/s3Client.ts
+++ b/web/src/core/adapters/s3Client/s3Client.ts
@@ -606,20 +606,25 @@ export function createS3Client(
 
             const { awsS3Client } = await getAwsS3Client();
 
-            await awsS3Client.send(
-                new (await import("@aws-sdk/client-s3")).DeleteObjectsCommand({
-                    Bucket: bucketName,
-                    Delete: {
-                        Objects: paths.map(path => {
-                            const { objectName } =
-                                bucketNameAndObjectNameFromS3Path(path);
-                            return {
-                                Key: objectName
-                            };
-                        })
-                    }
-                })
-            );
+            try {
+                await awsS3Client.send(
+                    new (await import("@aws-sdk/client-s3")).DeleteObjectsCommand({
+                        Bucket: bucketName,
+                        Delete: {
+                            Objects: paths.map(path => {
+                                const { objectName } =
+                                    bucketNameAndObjectNameFromS3Path(path);
+                                return {
+                                    Key: objectName
+                                };
+                            })
+                        }
+                    })
+                );
+            } catch (err) {
+                console.warn("Bulk delete failed, falling back to single deletes:", err);
+                await Promise.all(paths.map(path => s3Client.deleteFile({ path })));
+            }
         },
         getFileDownloadUrl: async ({ path, validityDurationSecond }) => {
             const { bucketName, objectName } = bucketNameAndObjectNameFromS3Path(path);


### PR DESCRIPTION
Since commit [5033f5b](https://github.com/InseeFrLab/onyxia/commit/5033f5bdd125a93bbcd982b57b8e48f9b331ee81) and the upgrade of @aws-sdk/client-s3, the default object integrity check has changed. The SDK now uses CRC32 instead of MD5.

However, some S3-compatible solutions do not support this change. As a result, in certain Onyxia instances, users are unable to delete objects when using bulk deletion. See the [AWS documentation](https://github.com/aws/aws-sdk-js-v3/blob/main/supplemental-docs/MD5_FALLBACK.md) for more details.

This PR introduces a fallback mechanism:
	•	We try bulk deletion first (for efficiency).
	•	If it fails, we fall back to deleting objects one by one.