### PR TITLE
There is no standardized way to request aud

### DIFF
--- a/web/src/core/adapters/oidc/oidc.ts
+++ b/web/src/core/adapters/oidc/oidc.ts
@@ -24,7 +24,6 @@ export async function createOidc<AutoLogin extends boolean>(
         issuerUri,
         clientId,
         scope_spaceSeparated,
-        audience,
         transformBeforeRedirectForKeycloakTheme,
         getCurrentLang,
         extraQueryParams_raw,
@@ -38,15 +37,6 @@ export async function createOidc<AutoLogin extends boolean>(
         clientId,
         scopes: scope_spaceSeparated?.split(" "),
         transformUrlBeforeRedirect: ({ authorizationUrl, isSilent }) => {
-            if (audience !== undefined) {
-                authorizationUrl = addOrUpdateSearchParam({
-                    url: authorizationUrl,
-                    name: "audience",
-                    value: audience,
-                    encodeMethod: "www-form"
-                });
-            }
-
             add_extraQueryParams_raw: {
                 if (extraQueryParams_raw === undefined) {
                     break add_extraQueryParams_raw;

--- a/web/src/core/adapters/onyxiaApi/ApiTypes.ts
+++ b/web/src/core/adapters/onyxiaApi/ApiTypes.ts
@@ -281,7 +281,6 @@ export namespace ApiTypes {
         clientID: string;
         extraQueryParams?: string;
         scope?: string;
-        audience?: string;
         idleSessionLifetimeInSeconds?: number | string;
     };
 }

--- a/web/src/core/adapters/onyxiaApi/onyxiaApi.ts
+++ b/web/src/core/adapters/onyxiaApi/onyxiaApi.ts
@@ -171,7 +171,6 @@ export function createOnyxiaApi(params: {
                                   data.oidcConfiguration.extraQueryParams || undefined,
                               scope_spaceSeparated:
                                   data.oidcConfiguration.scope || undefined,
-                              audience: data.oidcConfiguration.audience || undefined,
                               idleSessionLifetimeInSeconds: (() => {
                                   const value =
                                       data.oidcConfiguration.idleSessionLifetimeInSeconds;
@@ -1069,7 +1068,6 @@ function apiTypesOidcConfigurationToOidcParams_Partial(
         clientId: oidcConfiguration?.clientID || undefined,
         extraQueryParams_raw: oidcConfiguration?.extraQueryParams || undefined,
         scope_spaceSeparated: oidcConfiguration?.scope || undefined,
-        audience: oidcConfiguration?.audience || undefined,
         idleSessionLifetimeInSeconds: (() => {
             const value = oidcConfiguration?.idleSessionLifetimeInSeconds;
 

--- a/web/src/core/ports/OnyxiaApi/OidcParams.ts
+++ b/web/src/core/ports/OnyxiaApi/OidcParams.ts
@@ -1,7 +1,6 @@
 export type OidcParams = {
     issuerUri: string;
     clientId: string;
-    audience: string | undefined;
     extraQueryParams_raw: string | undefined;
     scope_spaceSeparated: string | undefined;
     idleSessionLifetimeInSeconds: number | undefined;


### PR DESCRIPTION
The `oidc.audience` parameter is purely a **server-side validation setting**, it’s only used by **Onyxia-API**.  
Its sole purpose is to let the API optionally validate the `aud` claim of incoming Access Tokens.  

It has **no effect** on how tokens are requested or issued by the OIDC client,  
and it doesn’t apply to other resource servers like Vault, MinIO, or the Kubernetes API.  
Those services are configured independently; this parameter doesn’t influence their OIDC setup.

There’s no standardized way to ensure that an OIDC client receives an access token with a specific `aud` claim.  
The behavior depends on the provider:

- **Auth0**, You can append `audience=xxx` to the authorization URL.  
  If configured properly, the issued Access Token will include `xxx` in its `aud` array.  
- **Keycloak**, The `aud` claim is essentially fixed per client,  
  since Keycloak conflates “application” and “resource server” into a single entity.  
  Each OIDC client represents an application talking to one specific resource server.  
- **Microsoft Entra ID**, You can request a particular `scope` linked to a declared API,  
  which in turn affects the `aud` claim of the issued Access Token.

In short: **it depends on your provider**.  
If your resource servers require a specific audience, use provider-specific settings such as:  
```yaml
extraQueryParams: "audience=https://datalab.my-domain.net/api"
# or
scope: "profile <Application ID URI (Onyxia - API)>/<scope name (usually access_as_user)>"
```

The documentation has been updated accordingly:  
https://github.com/InseeFrLab/docs.onyxia.sh/commit/efc021ae0ebb0279341b56f2963258f655a8bede  

@olevitt, I don’t recall if the API currently documents `audience` for resource servers oidc configuration or passes it explicitly.  
If it does, it would be best to remove it, it’s misleading and entirely my fault for including it.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified OIDC integration by removing the audience parameter from configuration and sign-in redirect handling.
  - Authorization URLs no longer include an audience query parameter.
  - Configuration and type surfaces reduced to eliminate unused options.
  - No changes to ui_locales or extra query parameters; typical sign-in flows remain unaffected.

- Chores
  - Updated public configuration schema to reflect the removal of the audience field, ensuring consistency across settings and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->