### PR TITLE
Revert "ci: move to `actions/checkout@v5` and use cache from `setup-node`"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: yarn.lock
+          cache-dependency-path: web/yarn.lock
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
@@ -35,6 +35,9 @@ jobs:
 
   test_helm-chart:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: helm-chart
     steps:
       - uses: actions/checkout@v5
         with:
@@ -81,7 +84,7 @@ jobs:
       - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           push: true
-          context: .
+          context: web
           tags: ${{needs.prepare_release.outputs.new_web_docker_image_tags}}
           platforms: "${{ needs.prepare_release.outputs.new_chart_version != '' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}"
           cache-from: type=gha

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: web/yarn.lock
-
       - run: yarn test
       - run: yarn build
       - run: npx keycloakify build
@@ -36,7 +34,7 @@ jobs:
         with:
           path: helm-chart
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
-      - run: helm lint helm-chart/.
+      - run: helm lint .
 
   prepare_release:
     needs:
@@ -94,7 +92,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: web/yarn.lock
       - run: yarn build-keycloak-theme
         env:
           KEYCLOAKIFY_THEME_VERSION: ${{needs.prepare_release.outputs.new_chart_version}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,8 +76,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{needs.prepare_release.outputs.target_commit}}
-          sparse-checkout: |
-            web
+          path: web
       - uses: docker/setup-qemu-action@v3.0.0
       - uses: docker/setup-buildx-action@v3.0.0
       - uses: docker/login-action@v3.0.0
@@ -87,7 +86,7 @@ jobs:
       - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           push: true
-          context: web
+          context: .
           tags: ${{needs.prepare_release.outputs.new_web_docker_image_tags}}
           platforms: "${{ needs.prepare_release.outputs.new_chart_version != '' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}"
           cache-from: type=gha
@@ -97,20 +96,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare_release
     if: needs.prepare_release.outputs.new_chart_version != ''
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v5
         with:
+          path: web
           ref: ${{needs.prepare_release.outputs.target_commit}}
-          sparse-checkout: |
-            web
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
           cache-dependency-path: web/yarn.lock
-      - run: yarn install --frozen-lockfile
       - run: yarn build-keycloak-theme
         env:
           KEYCLOAKIFY_THEME_VERSION: ${{needs.prepare_release.outputs.new_chart_version}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,19 +16,15 @@ permissions:
 jobs:
   test_web:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
-          sparse-checkout: |
-            web
+          path: web
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: web/yarn.lock
+          cache-dependency-path: yarn.lock
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
@@ -43,8 +39,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
-          sparse-checkout: |
-            helm-chart
+          path: helm-chart
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
       - run: helm lint .
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
-          path: web
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
@@ -42,7 +41,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
-          path: helm-chart
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
       - run: helm lint .
 
@@ -70,11 +68,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare_release
     if: needs.prepare_release.outputs.new_web_docker_image_tags != ''
+    defaults:
+      run:
+        working-directory: web
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{needs.prepare_release.outputs.target_commit}}
-          path: web
       - uses: docker/setup-qemu-action@v3.0.0
       - uses: docker/setup-buildx-action@v3.0.0
       - uses: docker/login-action@v3.0.0
@@ -84,7 +84,7 @@ jobs:
       - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           push: true
-          context: web
+          context: .
           tags: ${{needs.prepare_release.outputs.new_web_docker_image_tags}}
           platforms: "${{ needs.prepare_release.outputs.new_chart_version != '' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}"
           cache-from: type=gha

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: yarn.lock
-      - run: yarn install --frozen-lockfile
+          cache-dependency-path: web/yarn.lock
+
       - run: yarn test
       - run: yarn build
       - run: npx keycloakify build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: web/yarn.lock
 
       - run: yarn test
       - run: yarn build
@@ -32,9 +31,6 @@ jobs:
 
   test_helm-chart:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: helm-chart
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,6 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.ref }}
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
@@ -40,9 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.ref }}
+          path: helm-chart
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
-      - run: helm lint .
+      - run: helm lint helm-chart/.
 
   prepare_release:
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,14 +16,14 @@ permissions:
 jobs:
   test_web:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v5
+        with:
+          path: web
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
+          cache-dependency-path: web/yarn.lock
 
       - run: yarn test
       - run: yarn build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,9 @@ permissions:
 jobs:
   test_web:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
     steps:
       - uses: actions/checkout@v5
         with:
@@ -32,9 +35,6 @@ jobs:
 
   test_helm-chart:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: helm-chart
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,6 @@ jobs:
       - run: yarn test
       - run: yarn build
       - run: npx keycloakify build
-        env:
-          XDG_CACHE_HOME: /home/runner/.cache/yarn
 
   test_helm-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,12 +17,15 @@ jobs:
   test_web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: InseeFrLab/onyxia@gh-actions
         with:
-          path: web
-      - uses: actions/setup-node@v5
-        with:
-          cache: "yarn"
+          action_name: checkout
+          sub_directory: web
+      - uses: actions/setup-node@v4.1.0
+      # Install dependencies with caching
+      - uses: bahmutov/npm-install@e5fe105da2400070b5345aeb71fcb1ef5d4b2d1f
+        env:
+          XDG_CACHE_HOME: "/home/runner/.cache/yarn"
       - run: yarn test
       - run: yarn build
       - run: npx keycloakify build
@@ -30,9 +33,10 @@ jobs:
   test_helm-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: InseeFrLab/onyxia@gh-actions
         with:
-          path: helm-chart
+          action_name: checkout
+          sub_directory: helm-chart
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
       - run: helm lint .
 
@@ -61,10 +65,11 @@ jobs:
     needs: prepare_release
     if: needs.prepare_release.outputs.new_web_docker_image_tags != ''
     steps:
-      - uses: actions/checkout@v5
+      - uses: InseeFrLab/onyxia@gh-actions
         with:
-          path: web
-          ref: ${{needs.prepare_release.outputs.target_commit}}
+          action_name: checkout
+          sub_directory: web
+          sha: ${{needs.prepare_release.outputs.target_commit}}
       - uses: docker/setup-qemu-action@v3.0.0
       - uses: docker/setup-buildx-action@v3.0.0
       - uses: docker/login-action@v3.0.0
@@ -85,13 +90,16 @@ jobs:
     needs: prepare_release
     if: needs.prepare_release.outputs.new_chart_version != ''
     steps:
-      - uses: actions/checkout@v5
+      - uses: InseeFrLab/onyxia@gh-actions
         with:
-          path: web
-          ref: ${{needs.prepare_release.outputs.target_commit}}
-      - uses: actions/setup-node@v5
-        with:
-          cache: "yarn"
+          action_name: checkout
+          sub_directory: web
+          sha: ${{needs.prepare_release.outputs.target_commit}}
+      - uses: actions/setup-node@v4.1.0
+      # Install dependencies with caching
+      - uses: bahmutov/npm-install@e5fe105da2400070b5345aeb71fcb1ef5d4b2d1f
+        env:
+          XDG_CACHE_HOME: "/home/runner/.cache/yarn"
       - run: yarn build-keycloak-theme
         env:
           KEYCLOAKIFY_THEME_VERSION: ${{needs.prepare_release.outputs.new_chart_version}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: web/yarn.lock
+          cache-dependency-path: yarn.lock
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
@@ -68,12 +68,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare_release
     if: needs.prepare_release.outputs.new_web_docker_image_tags != ''
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v5
         with:
+          path: web
           ref: ${{needs.prepare_release.outputs.target_commit}}
       - uses: docker/setup-qemu-action@v3.0.0
       - uses: docker/setup-buildx-action@v3.0.0


### PR DESCRIPTION
Reverts InseeFrLab/onyxia#1036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined continuous integration pipeline for improved reliability and performance.
  * Optimized source checkout and caching to reduce build times.
  * Enhanced release preparation to ensure consistent versioning and commit references.
  * Updated build tooling versions for better stability.
  * Adjusted build contexts to simplify Docker image creation and publishing.
  * Improved handling of multi-component workflows (web and chart) for clearer, more maintainable CI steps.

No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->