### PR TITLE
ci: move to `actions/checkout@v5` and use cache from `setup-node` (was #1036)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
+          cache-dependency-path: web/yarn.lock
 
       - run: yarn test
       - run: yarn build
@@ -31,6 +32,9 @@ jobs:
 
   test_helm-chart:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: helm-chart
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,12 +29,18 @@ jobs:
         with:
           cache: "yarn"
           cache-dependency-path: web/yarn.lock
+      - name: Cache Keycloakify
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/keycloakify
+          key: keycloakify-${{ runner.os }}
+
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
       - run: npx keycloakify build
         env:
-          XDG_CACHE_HOME: /home/runner/.cache/yarn
+          XDG_CACHE_HOME: /home/runner/.cache/keycloakify
 
   test_helm-chart:
     runs-on: ubuntu-latest
@@ -112,6 +118,11 @@ jobs:
         with:
           cache: "yarn"
           cache-dependency-path: web/yarn.lock
+      - name: Cache Keycloakify
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/keycloakify
+          key: keycloakify-${{ runner.os }}
       - run: yarn install --frozen-lockfile
       - run: yarn build-keycloak-theme
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,15 +17,12 @@ jobs:
   test_web:
     runs-on: ubuntu-latest
     steps:
-      - uses: InseeFrLab/onyxia@gh-actions
+      - uses: actions/checkout@v5
         with:
-          action_name: checkout
-          sub_directory: web
-      - uses: actions/setup-node@v4.1.0
-      # Install dependencies with caching
-      - uses: bahmutov/npm-install@e5fe105da2400070b5345aeb71fcb1ef5d4b2d1f
-        env:
-          XDG_CACHE_HOME: "/home/runner/.cache/yarn"
+          path: web
+      - uses: actions/setup-node@v5
+        with:
+          cache: "yarn"
       - run: yarn test
       - run: yarn build
       - run: npx keycloakify build
@@ -33,10 +30,9 @@ jobs:
   test_helm-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: InseeFrLab/onyxia@gh-actions
+      - uses: actions/checkout@v5
         with:
-          action_name: checkout
-          sub_directory: helm-chart
+          path: helm-chart
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
       - run: helm lint .
 
@@ -65,11 +61,10 @@ jobs:
     needs: prepare_release
     if: needs.prepare_release.outputs.new_web_docker_image_tags != ''
     steps:
-      - uses: InseeFrLab/onyxia@gh-actions
+      - uses: actions/checkout@v5
         with:
-          action_name: checkout
-          sub_directory: web
-          sha: ${{needs.prepare_release.outputs.target_commit}}
+          path: web
+          ref: ${{needs.prepare_release.outputs.target_commit}}
       - uses: docker/setup-qemu-action@v3.0.0
       - uses: docker/setup-buildx-action@v3.0.0
       - uses: docker/login-action@v3.0.0
@@ -90,16 +85,13 @@ jobs:
     needs: prepare_release
     if: needs.prepare_release.outputs.new_chart_version != ''
     steps:
-      - uses: InseeFrLab/onyxia@gh-actions
+      - uses: actions/checkout@v5
         with:
-          action_name: checkout
-          sub_directory: web
-          sha: ${{needs.prepare_release.outputs.target_commit}}
-      - uses: actions/setup-node@v4.1.0
-      # Install dependencies with caching
-      - uses: bahmutov/npm-install@e5fe105da2400070b5345aeb71fcb1ef5d4b2d1f
-        env:
-          XDG_CACHE_HOME: "/home/runner/.cache/yarn"
+          path: web
+          ref: ${{needs.prepare_release.outputs.target_commit}}
+      - uses: actions/setup-node@v5
+        with:
+          cache: "yarn"
       - run: yarn build-keycloak-theme
         env:
           KEYCLOAKIFY_THEME_VERSION: ${{needs.prepare_release.outputs.new_chart_version}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: web/yarn.lock
+          cache-dependency-path: yarn.lock
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
@@ -35,9 +35,6 @@ jobs:
 
   test_helm-chart:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: helm-chart
     steps:
       - uses: actions/checkout@v5
         with:
@@ -84,7 +81,7 @@ jobs:
       - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           push: true
-          context: web
+          context: .
           tags: ${{needs.prepare_release.outputs.new_web_docker_image_tags}}
           platforms: "${{ needs.prepare_release.outputs.new_chart_version != '' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}"
           cache-from: type=gha

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
+          path: web
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
@@ -41,6 +42,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
+          path: helm-chart
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
       - run: helm lint .
 
@@ -68,13 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare_release
     if: needs.prepare_release.outputs.new_web_docker_image_tags != ''
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{needs.prepare_release.outputs.target_commit}}
+          path: web
       - uses: docker/setup-qemu-action@v3.0.0
       - uses: docker/setup-buildx-action@v3.0.0
       - uses: docker/login-action@v3.0.0
@@ -84,7 +84,7 @@ jobs:
       - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           push: true
-          context: .
+          context: web
           tags: ${{needs.prepare_release.outputs.new_web_docker_image_tags}}
           platforms: "${{ needs.prepare_release.outputs.new_chart_version != '' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}"
           cache-from: type=gha

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,14 +16,14 @@ permissions:
 jobs:
   test_web:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
     steps:
       - uses: actions/checkout@v5
-        with:
-          path: web
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: web/yarn.lock
 
       - run: yarn test
       - run: yarn build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: yarn.lock
+          cache-dependency-path: web/yarn.lock
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
@@ -68,10 +68,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare_release
     if: needs.prepare_release.outputs.new_web_docker_image_tags != ''
+    defaults:
+      run:
+        working-directory: web
     steps:
       - uses: actions/checkout@v5
         with:
-          path: web
           ref: ${{needs.prepare_release.outputs.target_commit}}
       - uses: docker/setup-qemu-action@v3.0.0
       - uses: docker/setup-buildx-action@v3.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: web/yarn.lock
-
+          cache-dependency-path: yarn.lock
+      - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
       - run: npx keycloakify build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,6 +116,10 @@ jobs:
       - run: yarn build-keycloak-theme
         env:
           KEYCLOAKIFY_THEME_VERSION: ${{needs.prepare_release.outputs.new_chart_version}}
+      - name: Check for Keycloak JAR
+        run: |
+          echo "Checking for built JAR..."
+          find web/dist_keycloak -type f -name "*.jar" || (echo "❌ No JAR found in web/dist_keycloak" && exit 1)
       - uses: yogeshlonkar/wait-for-jobs@722e963a0bba35f55913d5372cd442f038a7c95a
         with:
           ignore-skipped: true
@@ -140,7 +144,7 @@ jobs:
           target_commitish: ${{needs.prepare_release.outputs.target_commit}}
           generate_release_notes: true
           files: |
-            web/dist_keycloak/*.jar
+            web/dist_keycloak/**/*.jar
             onyxia-${{needs.prepare_release.outputs.new_chart_version}}.tgz
         env:
           # NOTE: We can't use github.token because it would not trigger the dispatch workflow.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,6 @@ permissions:
 jobs:
   test_web:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web
     steps:
       - uses: actions/checkout@v5
         with:
@@ -35,6 +32,9 @@ jobs:
 
   test_helm-chart:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: helm-chart
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,7 @@ jobs:
           target_commitish: ${{needs.prepare_release.outputs.target_commit}}
           generate_release_notes: true
           files: |
-            dist_keycloak/*.jar
+            web/dist_keycloak/*.jar
             onyxia-${{needs.prepare_release.outputs.new_chart_version}}.tgz
         env:
           # NOTE: We can't use github.token because it would not trigger the dispatch workflow.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
+          cache-dependency-path: web/yarn.lock
+
       - run: yarn test
       - run: yarn build
       - run: npx keycloakify build
@@ -34,7 +36,7 @@ jobs:
         with:
           path: helm-chart
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
-      - run: helm lint .
+      - run: helm lint helm-chart/.
 
   prepare_release:
     needs:
@@ -92,6 +94,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
+          cache-dependency-path: web/yarn.lock
       - run: yarn build-keycloak-theme
         env:
           KEYCLOAKIFY_THEME_VERSION: ${{needs.prepare_release.outputs.new_chart_version}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,8 @@ jobs:
       - run: yarn test
       - run: yarn build
       - run: npx keycloakify build
+        env:
+          XDG_CACHE_HOME: /home/runner/.cache/yarn
 
   test_helm-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,15 +16,19 @@ permissions:
 jobs:
   test_web:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
-          path: web
+          sparse-checkout: |
+            web
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
-          cache-dependency-path: yarn.lock
+          cache-dependency-path: web/yarn.lock
       - run: yarn install --frozen-lockfile
       - run: yarn test
       - run: yarn build
@@ -39,7 +43,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
-          path: helm-chart
+          sparse-checkout: |
+            helm-chart
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
       - run: helm lint .
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,8 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
@@ -38,9 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          path: helm-chart
+          ref: ${{ github.ref }}
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
-      - run: helm lint helm-chart/.
+      - run: helm lint .
 
   prepare_release:
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{needs.prepare_release.outputs.target_commit}}
-          path: web
+          sparse-checkout: |
+            web
       - uses: docker/setup-qemu-action@v3.0.0
       - uses: docker/setup-buildx-action@v3.0.0
       - uses: docker/login-action@v3.0.0
@@ -86,7 +87,7 @@ jobs:
       - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           push: true
-          context: .
+          context: web
           tags: ${{needs.prepare_release.outputs.new_web_docker_image_tags}}
           platforms: "${{ needs.prepare_release.outputs.new_chart_version != '' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}"
           cache-from: type=gha
@@ -96,15 +97,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare_release
     if: needs.prepare_release.outputs.new_chart_version != ''
+    defaults:
+      run:
+        working-directory: web
     steps:
       - uses: actions/checkout@v5
         with:
-          path: web
           ref: ${{needs.prepare_release.outputs.target_commit}}
+          sparse-checkout: |
+            web
       - uses: actions/setup-node@v5
         with:
           cache: "yarn"
           cache-dependency-path: web/yarn.lock
+      - run: yarn install --frozen-lockfile
       - run: yarn build-keycloak-theme
         env:
           KEYCLOAKIFY_THEME_VERSION: ${{needs.prepare_release.outputs.new_chart_version}}


### PR DESCRIPTION
This PR re-applies the changes from **#1036**, which were reverted in **#1039** due to an issue with Keycloak theme upload.

- Adjusted path to `dist_keycloak`
- Added explicit check to fail when no JAR is found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Modernized CI pipelines for web and Helm to improve reliability and speed.
  * Implemented better caching and deterministic installs for consistent builds.
  * Added verification to ensure the Keycloak theme JAR is produced before releasing.
  * Refined artifact packaging paths for more accurate release bundles.
  * Aligned release steps for consistent tagging and artifact handling.
  * Adjusted Docker build context to streamline image publishing and reduce errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->