### PR TITLE
Enable DPoP if the AS supports it, unless the Go Onboarding API is en…

### DIFF
--- a/helm-chart/templates/web/deployment.yaml
+++ b/helm-chart/templates/web/deployment.yaml
@@ -41,6 +41,10 @@ spec:
               value: {{ $value | quote }}
             {{- end -}}
             {{- end }}
+          {{- if .Values.onboarding.enabled }}
+            - name: OIDC_DISABLE_DPOP
+              value: "true"
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.web.containerPort }}

--- a/web/.env
+++ b/web/.env
@@ -887,3 +887,6 @@ ONYXIA_VERSION_URL=
 SCREEN_SCALER=true
 
 OIDC_DEBUG_LOGS=false
+
+# NOTE: Temporary workaround until the Go onboarding API supports it.
+OIDC_DISABLE_DPOP=false

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -18,15 +18,19 @@ if (import.meta.env.DEV) {
         return;
     }
 
-    const [{ oidcEarlyInit }, { browserRuntimeFreeze }] = await Promise.all([
+    const [{ oidcEarlyInit }, { browserRuntimeFreeze }, { DPoP }] = await Promise.all([
         import("oidc-spa/entrypoint"),
-        import("oidc-spa/browser-runtime-freeze")
+        import("oidc-spa/browser-runtime-freeze"),
+        import.meta.env.OIDC_DISABLE_DPOP === "true"
+            ? { DPoP: undefined }
+            : import("oidc-spa/DPoP")
     ]);
 
     const { shouldLoadApp } = oidcEarlyInit({
         BASE_URL: import.meta.env.BASE_URL,
         securityDefenses: {
-            ...browserRuntimeFreeze()
+            ...browserRuntimeFreeze(),
+            ...DPoP?.({ mode: "auto" })
         }
     });
 

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -66,6 +66,7 @@ type ImportMetaEnv = {
   ONYXIA_VERSION_URL: string
   SCREEN_SCALER: string
   OIDC_DEBUG_LOGS: string
+  OIDC_DISABLE_DPOP: string
   // @user-defined-start
   /*
    * Here you can define your own special variables


### PR DESCRIPTION
…abled, in that case disable it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OIDC_DISABLE_DPOP configuration option to control DPoP usage in OIDC authentication flows. The environment variable defaults to false and can be disabled when required for specific deployment scenarios or system compatibility needs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->