### PR TITLE
Add Gateway API HTTPRoute support to chart

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -25,6 +25,23 @@ EOF
 helm install onyxia onyxia/onyxia --version "10.32.5" -f onyxia-values.yaml
 ```
 
+To expose Onyxia with the Kubernetes Gateway API instead of an Ingress, use an `HTTPRoute`:
+
+```bash
+cat << EOF > ./onyxia-values.yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: onyxia-gateway
+      namespace: infra-gateway
+      sectionName: web
+  hostnames:
+    - datalab.my-domain.net
+EOF
+
+helm install onyxia onyxia/onyxia --version "10.32.5" -f onyxia-values.yaml
+```
+
 ### Using the Keycloak Theme (Optional)
 
 If you use [Keycloak](https://www.keycloak.org/) as OIDC provider you can use the Onyxia theme.  
@@ -77,9 +94,15 @@ Below is a sample `onyxia-values.yaml` file that illustrates where to specify th
 
 ```diff
  ingress:
-     enabled: true
-     hosts:
-       - host: datalab.yourdomain.com
+      enabled: true
+      hosts:
+        - host: datalab.yourdomain.com
++httpRoute:
++    enabled: true
++    parentRefs:
++      - name: onyxia-gateway
++    hostnames:
++      - datalab.yourdomain.com
 +web:
 +    env:
 +      HEADER_LOGO=https://example.com/logo.svg

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -25,7 +25,8 @@ EOF
 helm install onyxia onyxia/onyxia --version "10.32.5" -f onyxia-values.yaml
 ```
 
-To expose Onyxia with the Kubernetes Gateway API instead of an Ingress, use an `HTTPRoute`:
+To expose Onyxia with the Kubernetes Gateway API instead of an Ingress, use an `HTTPRoute`.
+The `parentRefs` entries must point to the `Gateway` already configured by your cluster administrator:
 
 ```bash
 cat << EOF > ./onyxia-values.yaml
@@ -93,16 +94,6 @@ Documentation reference for the available configuration parameter of the Onyxia 
 Below is a sample `onyxia-values.yaml` file that illustrates where to specify the `api` and `web` configuration parameters.
 
 ```diff
- ingress:
-      enabled: true
-      hosts:
-        - host: datalab.yourdomain.com
-+httpRoute:
-+    enabled: true
-+    parentRefs:
-+      - name: onyxia-gateway
-+    hostnames:
-+      - datalab.yourdomain.com
 +web:
 +    env:
 +      HEADER_LOGO=https://example.com/logo.svg
@@ -123,6 +114,27 @@ Below is a sample `onyxia-values.yaml` file that illustrates where to specify th
 +              "id":"demo",
 +              "name":"Demo",
 +              # ...
+```
+
+Ingress example:
+
+```yaml
+ingress:
+  enabled: true
+  hosts:
+    - host: datalab.yourdomain.com
+```
+
+HTTPRoute example:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    # Reference the Gateway configured by your cluster administrator.
+    - name: onyxia-gateway
+  hostnames:
+    - datalab.yourdomain.com
 ```
 
 ## Catalogs `x-onyxia` specifications

--- a/helm-chart/templates/httproute.yaml
+++ b/helm-chart/templates/httproute.yaml
@@ -7,6 +7,10 @@
 {{- $svcPortWeb := .Values.web.service.port -}}
 {{- $svcPortOnboarding := .Values.onboarding.service.port -}}
 {{- $onboardingEnabled := .Values.onboarding.enabled -}}
+{{- $parentRefs := .Values.httpRoute.parentRefs -}}
+{{- if or (not $parentRefs) (eq (len $parentRefs) 0) -}}
+{{- fail "httpRoute.parentRefs must contain at least one Gateway reference when httpRoute.enabled=true" -}}
+{{- end -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -19,8 +23,8 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-    {{- range .Values.httpRoute.parentRefs }}
-    - name: {{ .name | quote }}
+    {{- range $parentRefs }}
+    - name: {{ required "httpRoute.parentRefs[].name is required when httpRoute.enabled=true" .name | quote }}
       {{- with .namespace }}
       namespace: {{ . | quote }}
       {{- end }}

--- a/helm-chart/templates/httproute.yaml
+++ b/helm-chart/templates/httproute.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullNameApi := include "onyxia.api.fullname" . -}}
+{{- $fullNameWeb := include "onyxia.web.fullname" . -}}
+{{- $fullNameOnboarding := include "onyxia.onboarding.fullname" . -}}
+{{- $fullName := include "onyxia.fullname" . -}}
+{{- $svcPortApi := .Values.api.service.port -}}
+{{- $svcPortWeb := .Values.web.service.port -}}
+{{- $svcPortOnboarding := .Values.onboarding.service.port -}}
+{{- $onboardingEnabled := .Values.onboarding.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "onyxia.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.httpRoute.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name | quote }}
+      {{- with .namespace }}
+      namespace: {{ . | quote }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . | quote }}
+      {{- end }}
+      {{- with .port }}
+      port: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if $onboardingEnabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/onboarding
+      backendRefs:
+        - name: {{ $fullNameOnboarding }}
+          port: {{ $svcPortOnboarding }}
+    {{- end }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: {{ $fullNameApi }}
+          port: {{ $svcPortApi }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullNameWeb }}
+          port: {{ $svcPortWeb }}
+{{- end }}

--- a/helm-chart/templates/httproute.yaml
+++ b/helm-chart/templates/httproute.yaml
@@ -13,8 +13,8 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "onyxia.labels" . | nindent 4 }}
-  annotations:
   {{- with .Values.httpRoute.annotations }}
+  annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -13,6 +13,17 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs:
+    - name: ""
+      # namespace:
+      # sectionName:
+      # port:
+  hostnames:
+    - chart-example.local
+
 route:
   enabled: false
   annotations: {} # route.openshift.io/termination: "reencrypt"

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -17,7 +17,9 @@ httpRoute:
   enabled: false
   annotations: {}
   parentRefs:
-    - name: ""
+    # parentRefs must reference the Gateway configured by the cluster administrator.
+    # parentRefs[0].name is required when httpRoute.enabled=true.
+    - name: onyxia-gateway
       # namespace:
       # sectionName:
       # port:


### PR DESCRIPTION
This pull request introduces support for exposing Onyxia via the Kubernetes Gateway API using an `HTTPRoute`.

in a first step for the more general support #1062 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add optional support for exposing Onyxia via Kubernetes Gateway API (HTTPRoute) as an alternative to Ingress.
  * New configuration options to enable HTTPRoute and specify annotations, parent references, and hostnames.

* **Documentation**
  * README updated with HTTPRoute examples and guidance for deploying via the Gateway API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->