### PR TITLE
Wire HTTPRoute defaults through web context

### DIFF
--- a/web/src/core/adapters/onyxiaApi/ApiTypes.ts
+++ b/web/src/core/adapters/onyxiaApi/ApiTypes.ts
@@ -21,6 +21,15 @@ export type ApiTypes = {
                     ingressClassName: string;
                     ingress?: boolean;
                     route?: boolean;
+                    httpRoute?: {
+                        enabled: boolean;
+                        parentRefs: {
+                            name: string;
+                            namespace?: string;
+                            sectionName?: string;
+                            port?: number;
+                        }[];
+                    };
                     istio?: {
                         enabled: boolean;
                         gateways: string[];

--- a/web/src/core/adapters/onyxiaApi/onyxiaApi.ts
+++ b/web/src/core/adapters/onyxiaApi/onyxiaApi.ts
@@ -214,6 +214,7 @@ export function createOnyxiaApi(params: {
                             ingressClassName: apiRegion.services.expose.ingressClassName,
                             ingress: apiRegion.services.expose.ingress,
                             route: apiRegion.services.expose.route,
+                            httpRoute: apiRegion.services.expose.httpRoute,
                             customValues: apiRegion.services.customValues,
                             istio: apiRegion.services.expose.istio,
                             initScriptUrl: apiRegion.services.initScript,

--- a/web/src/core/ports/OnyxiaApi/DeploymentRegion.ts
+++ b/web/src/core/ports/OnyxiaApi/DeploymentRegion.ts
@@ -11,6 +11,17 @@ export type DeploymentRegion = {
     ingressClassName: string | undefined;
     ingress: boolean | undefined;
     route: boolean | undefined;
+    httpRoute:
+        | {
+              enabled: boolean;
+              parentRefs: {
+                  name: string;
+                  namespace?: string;
+                  sectionName?: string;
+                  port?: number;
+              }[];
+          }
+        | undefined;
     customValues: Record<string, unknown> | undefined;
     istio:
         | {

--- a/web/src/core/ports/OnyxiaApi/XOnyxia.ts
+++ b/web/src/core/ports/OnyxiaApi/XOnyxia.ts
@@ -182,6 +182,17 @@ export type XOnyxiaContext = {
         ingressClassName: string | undefined;
         ingress: boolean | undefined;
         route: boolean | undefined;
+        httpRoute:
+            | {
+                  enabled: boolean;
+                  parentRefs: {
+                      name: string;
+                      namespace?: string;
+                      sectionName?: string;
+                      port?: number;
+                  }[];
+              }
+            | undefined;
         istio:
             | {
                   enabled: boolean;

--- a/web/src/core/usecases/launcher/decoupledLogic/computeHelmValues.test.ts
+++ b/web/src/core/usecases/launcher/decoupledLogic/computeHelmValues.test.ts
@@ -851,6 +851,66 @@ describe(symToStr({ computeHelmValues }), () => {
         expect(got).toStrictEqual(expected);
     });
 
+    it("supports httpRoute parentRefs from x-onyxia context", () => {
+        const xOnyxiaContext = {
+            s3: {},
+            k8s: {
+                httpRoute: {
+                    enabled: true,
+                    parentRefs: [
+                        {
+                            name: "shared-gateway",
+                            namespace: "gateway-system",
+                            sectionName: "web"
+                        }
+                    ]
+                }
+            }
+        };
+
+        const got = computeHelmValues({
+            helmValuesSchema: {
+                type: "object",
+                properties: {
+                    httpRoute: {
+                        type: "object",
+                        properties: {
+                            parentRefs: {
+                                type: "array",
+                                "x-onyxia": {
+                                    overwriteDefaultWith: "k8s.httpRoute.parentRefs"
+                                },
+                                items: {
+                                    type: "object",
+                                    properties: {
+                                        name: { type: "string" },
+                                        namespace: { type: "string" },
+                                        sectionName: { type: "string" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            helmValuesYaml: YAML.stringify({}),
+            xOnyxiaContext,
+            infoAmountInHelmValues: "user provided"
+        });
+
+        expect(got.helmValues).toStrictEqual({
+            httpRoute: {
+                parentRefs: [
+                    {
+                        name: "shared-gateway",
+                        namespace: "gateway-system",
+                        sectionName: "web"
+                    }
+                ]
+            }
+        });
+    });
+
     it("default array work even when extra properties in objects", () => {
         const xOnyxiaContext = {
             s3: {},

--- a/web/src/core/usecases/launcher/thunks.ts
+++ b/web/src/core/usecases/launcher/thunks.ts
@@ -767,6 +767,7 @@ export const protectedThunks = {
                     ingressClassName: region.ingressClassName,
                     ingress: region.ingress,
                     route: region.route,
+                    httpRoute: region.httpRoute,
                     istio: region.istio,
                     randomSubdomain: `${Math.floor(Math.random() * 1000000)}`,
                     initScriptUrl: region.initScriptUrl,


### PR DESCRIPTION
This pull request introduces support for exposing Onyxia using the Kubernetes Gateway API via `HTTPRoute`, alongside documentation and code changes to enable this new feature. The most important changes are grouped below by theme.

depend on #1061 , #https://github.com/InseeFrLab/onyxia-api/pull/664
for #1062 

**Gateway API / HTTPRoute support**

* Added a new `httproute.yaml` Helm template to generate `HTTPRoute` resources when `httpRoute.enabled` is true, including validation of `parentRefs` and backend routing for API, web, and onboarding services.
* Extended `values.yaml` to include a new `httpRoute` configuration section, allowing specification of `enabled`, `annotations`, `parentRefs`, and `hostnames`.

**Documentation updates**

* Updated `README.md` with instructions and examples for configuring Onyxia with the Gateway API (`HTTPRoute`), including sample `onyxia-values.yaml` files and clear guidance on referencing cluster Gateways. [[1]](diffhunk://#diff-3346b8bdb8fcc321c76420ed9c4b3c5275da237deee0a96b7a5f34f20e94632eR28-R45) [[2]](diffhunk://#diff-3346b8bdb8fcc321c76420ed9c4b3c5275da237deee0a96b7a5f34f20e94632eR119-R139) [[3]](diffhunk://#diff-3346b8bdb8fcc321c76420ed9c4b3c5275da237deee0a96b7a5f34f20e94632eL79-L82)

**API and context propagation**

* Added `httpRoute` fields to the Onyxia API types, deployment region, and context interfaces in the web codebase to propagate Gateway API configuration from backend to frontend and service deployment logic. [[1]](diffhunk://#diff-ed7c74a6e4293172523a91c180dbc2fab57f50b6b396b9b8660aa8c4e556782dR24-R32) [[2]](diffhunk://#diff-76c0aab4be71440d7762559ea85dcf854e81ab02ed2a4ec358c4d9901b1ee73bR14-R24) [[3]](diffhunk://#diff-0454402b69c4a43d017d77112dfd144be9ee856641605c1cb27d69e7edfd09e0R185-R195) [[4]](diffhunk://#diff-3f6921d5362e177431337c5b8dc4c79ae5ea9d92a458e84a59484a0b23819793R217) [[5]](diffhunk://#diff-c0f8963466a2cc7c9d696eab0ecaeb62bd30d947c4e948b20e45a25f515c02ecR770)

**Testing**

* Added a new test case to verify that `computeHelmValues` correctly supports `httpRoute.parentRefs` propagation from the `x-onyxia` context, ensuring that the new configuration is handled as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP route configuration support for deployment regions with enable/disable control.
  * Introduced parent reference definitions allowing customization of namespace and port settings for deployments.

* **Tests**
  * Added test coverage for HTTP route parent reference configuration derivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->