### PR TITLE
Update health probe path to new one

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 10.32.6
+version: 10.32.7

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -391,21 +391,21 @@ onboarding:
 
   livenessProbe:
     enabled: true
-    path: /
+    path: /healthz
     failureThreshold: 3
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
   readinessProbe:
     enabled: true
-    path: /
+    path: /healthz
     failureThreshold: 3
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
   startupProbe:
     enabled: false
-    path: /
+    path: /healthz
     failureThreshold: 3
     periodSeconds: 10
     successThreshold: 1


### PR DESCRIPTION
Health probes fail for the latest chart version because the newer versions of onyxia-onboarding changed the endpoint from / to /healthz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected health-check probe paths for liveness, readiness, and startup to the proper endpoint.

* **Chores**
  * Bumped Helm chart version to 10.32.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->