### PR TITLE
Add gke-ephemeral example: Onyxia on GKE Autopilot with ingress-nginx + cert-manager

### DIFF
--- a/helm-chart/.helmignore
+++ b/helm-chart/.helmignore
@@ -21,3 +21,13 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Repository examples are not part of the installable chart archive.
+examples/
+
+# Terraform/OpenTofu local state and credentials.
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfvars

--- a/helm-chart/examples/gke-ephemeral/.gitignore
+++ b/helm-chart/examples/gke-ephemeral/.gitignore
@@ -1,0 +1,16 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+*.local.yaml
+*.local.yml
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+*.tfplan
+

--- a/helm-chart/examples/gke-ephemeral/README.md
+++ b/helm-chart/examples/gke-ephemeral/README.md
@@ -338,6 +338,81 @@ kubectl delete namespace cert-smoketest
 
 On a healthy setup the certificate becomes `Ready=True` in 10–30 seconds.
 
+## Real Google Identity — Keycloak IdP (recommended)
+
+The default `oauth2-proxy` gateway above only **gates** access to Onyxia; the
+platform itself runs in `authentication.mode: none` and sees every user as the
+mock account `default` / `John`. For multi-user usage with real Gmail identities
+propagated inside Onyxia (per-user projects, vault dirs, namespaces), enable
+the optional in-cluster Keycloak with a Google identity provider.
+
+This mirrors the SSP Cloud / INSEE production pattern (Onyxia → Keycloak →
+Google) and works out of the box.
+
+### Enable in tfvars
+
+```hcl
+enable_keycloak         = true
+keycloak_hostname       = "auth.onyxia.example.com"  # must resolve to the same LB
+keycloak_admin_password = "<strong password>"
+```
+
+DNS: add an `A` record `auth.onyxia.example.com → <services_ingress_nginx_ip>`.
+
+### Add the Keycloak callback to Google OAuth
+
+In Google Cloud Console → APIs & Services → Credentials → your OAuth 2.0 Web
+client, add the redirect URI:
+
+```
+https://auth.onyxia.example.com/realms/onyxia/broker/google/endpoint
+```
+
+### Apply + configure the realm
+
+```bash
+tofu apply
+
+KC_ADMIN_PASSWORD="<your tfvars password>" \
+GOOGLE_CLIENT_ID="<your Google client id>" \
+ONYXIA_HOSTNAME="onyxia.example.com" \
+KEYCLOAK_HOSTNAME="auth.onyxia.example.com" \
+  ./scripts/keycloak-init.sh
+```
+
+`keycloak-init.sh` is idempotent. It creates the `onyxia` realm, a public PKCE
+client called `onyxia`, and a Google identity provider — exactly what Onyxia
+expects. Re-run after every Keycloak restart (the chart ships an H2 in-memory
+database by default; for persistence wire an external Postgres via
+`database.*` in the Helm release).
+
+### Switch Onyxia to OIDC against Keycloak
+
+In `onyxia-gke-public-values.yaml` (already wired when `enable_keycloak=true`):
+
+- `ingress.enabled: true` with `class: nginx` + `cert-manager` annotation.
+- `nginx.ingress.kubernetes.io/configuration-snippet` overrides the strict
+  default `frame-src` CSP so oidc-spa can iframe Keycloak's login.
+- `api.env.authentication.mode: openidconnect`
+- `api.env.oidc.issuer-uri: "https://auth.<your hostname>/realms/onyxia"`
+- `api.env.oidc.clientID: "onyxia"`
+- **`api.env.oidc.username-claim: sub`** — must produce an RFC1123-compliant
+  token (no dots/@). The Keycloak `sub` UUID is always safe. Using `email`
+  breaks because Onyxia API filters non-RFC1123 namespaces and the user-project
+  is dropped.
+- `web.env.OIDC_DISABLE_DPOP: "true"` — Keycloak doesn't accept the `DPoP`
+  header on the token endpoint by default.
+
+Then disable the oauth2-proxy gateway (`enable_oauth2_proxy_gateway=false`)
+and `services_ingress_nginx_oauth2_auth=false`.
+
+### Result
+
+`https://onyxia.<your hostname>` → "Connexion" → Keycloak login screen → click
+**Google** → Google consent → return to Onyxia logged in as **the real Gmail
+user**. The Account page shows the real `fabien.antoine@gmail.com` email and a
+per-user project namespace `user-<keycloak-uuid>`.
+
 ## GKE Autopilot Gotchas
 
 GKE Autopilot is a great fit for ephemeral test clusters, but enforces a few

--- a/helm-chart/examples/gke-ephemeral/README.md
+++ b/helm-chart/examples/gke-ephemeral/README.md
@@ -1,0 +1,399 @@
+# Ephemeral GKE Test Deployment
+
+Deploy Onyxia on a short-lived GKE Autopilot cluster while keeping the Onyxia
+Helm chart fully provider-agnostic.
+
+The example layers a small amount of cloud-specific glue (OpenTofu/Terraform)
+on top of the standard chart. The Kubernetes/Helm contract is untouched.
+
+The lifecycle is split into three OpenTofu roots, from durable to disposable:
+
+- `terraform/base`: durable, low-cost resources (backup bucket).
+- `terraform/cluster`: the disposable GKE Autopilot cluster and VPC.
+- `terraform/app`: the disposable Onyxia Helm release plus ingress-nginx +
+  cert-manager (Let's Encrypt) on that cluster.
+
+The expected hibernation pattern is to destroy `terraform/app` and
+`terraform/cluster`, keeping only `terraform/base`. Resume by applying both
+roots again.
+
+## Cost Profile
+
+While `terraform/app` and `terraform/cluster` are up, expect:
+
+| Item                                       | ~$ / day                              |
+|--------------------------------------------|---------------------------------------|
+| GKE Autopilot control plane                | $2.40 (often $0 under GCP free tier)  |
+| 1 regional network LB (ingress-nginx)      | $0.60                                 |
+| Onyxia + ingress-nginx + cert-manager pods | $0.70                                 |
+| One running user service (e.g. Jupyter)    | $1–2                                  |
+
+Idle target ≈ **$3–4 / day**. Shut down user services in the Onyxia UI when you
+stop working; they are by far the biggest driver of variable cost.
+
+After destroying the `app` and `cluster` roots, only the backup bucket from
+`base` remains, at well under $1 / month.
+
+For a stricter cap, create a GCP budget alert (you should anyway):
+
+```bash
+gcloud services enable billingbudgets.googleapis.com cloudbilling.googleapis.com --project=PROJECT_ID
+gcloud billing budgets create \
+  --billing-account=$(gcloud beta billing projects describe PROJECT_ID --format='value(billingAccountName)' | sed 's|billingAccounts/||') \
+  --display-name="onyxia-gke-25usd" \
+  --budget-amount=25 \
+  --threshold-rule=percent=0.5 \
+  --threshold-rule=percent=0.9 \
+  --threshold-rule=percent=1.0 \
+  --filter-projects=projects/PROJECT_ID
+```
+
+## Prerequisites
+
+Run from any workstation with `gcloud`, `kubectl`, `helm`, `curl`, `tar` and
+`sudo` available. The bootstrap script installs the rest:
+
+```bash
+cd helm-chart/examples/gke-ephemeral
+./scripts/bootstrap.sh
+```
+
+The script is idempotent. It installs:
+
+- `tofu` (OpenTofu) under `~/.local/bin/` — no sudo.
+- `gke-gcloud-auth-plugin` via Google's apt repo — sudo, once.
+
+If you prefer to install those yourself, that works too; the script just skips
+what is already on PATH.
+
+## Quickstart
+
+Bring the example up:
+
+```bash
+PROJECT_ID=my-gcp-project ./scripts/up.sh
+```
+
+Check what is running and the indicative cost:
+
+```bash
+PROJECT_ID=my-gcp-project ./scripts/status.sh
+```
+
+Tear the app layer down (keeps the cluster):
+
+```bash
+PROJECT_ID=my-gcp-project ./scripts/down.sh
+```
+
+Tear everything down (cluster + VPC):
+
+```bash
+PROJECT_ID=my-gcp-project ./scripts/down.sh --full
+```
+
+The sections below explain each layer if you want to drive `tofu` directly.
+
+## Configure Durable Base
+
+```bash
+cd helm-chart/examples/gke-ephemeral/terraform/base
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit:
+
+```hcl
+project_id         = "my-gcp-project"
+region             = "us-central1"
+bucket_location    = "US-CENTRAL1"
+backup_bucket_name = "my-gcp-project-onyxia-test-backup"
+```
+
+Apply once:
+
+```bash
+tofu init
+tofu apply
+```
+
+## Create The Cluster
+
+```bash
+cd ../cluster
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit:
+
+```hcl
+project_id   = "my-gcp-project"
+region       = "us-central1"
+cluster_name = "onyxia-test"
+```
+
+Create the disposable cluster:
+
+```bash
+tofu init
+tofu apply
+gcloud container clusters get-credentials onyxia-test \
+  --project my-gcp-project --location us-central1
+```
+
+## Deploy Onyxia (Local-Only Mode)
+
+The default `terraform/app` apply installs Onyxia behind no public endpoint —
+useful for a private smoke test through `kubectl port-forward`.
+
+```bash
+cd ../app
+cp terraform.tfvars.example terraform.tfvars
+tofu init
+tofu apply
+```
+
+Then start the two port-forwards and the local proxy in three terminals
+(commands also exposed as outputs):
+
+```bash
+kubectl -n onyxia port-forward --address 127.0.0.1 svc/onyxia-web 18082:80
+kubectl -n onyxia port-forward --address 127.0.0.1 svc/onyxia-api 18083:80
+ONYXIA_PROXY_PORT=18080 ONYXIA_WEB_PORT=18082 ONYXIA_API_PORT=18083 \
+  node ../../scripts/onyxia-local-proxy.mjs
+```
+
+Open <http://127.0.0.1:18080>.
+
+The proxy keeps the same browser-visible shape as the chart Ingress template:
+`/api` to the API service, `/` to the web service.
+
+## Public Mode — ingress-nginx + cert-manager (Let's Encrypt)
+
+The example also supports a fully public deployment behind a **single regional
+network LB**, served by `ingress-nginx`, with HTTPS certificates issued
+automatically by `cert-manager` against Let's Encrypt production. This is the
+recommended public mode: provider-agnostic, one LB only, fast cert issuance.
+
+### Pieces installed by `terraform/app`
+
+- `ingress-nginx` Helm release in namespace `ingress-nginx` — creates the
+  single regional network LB.
+- `cert-manager` Helm release in namespace `cert-manager`.
+- A `ClusterIssuer` named `letsencrypt-prod`, registered with your email.
+- An Onyxia auth-gateway `Ingress` (created by Terraform) with class `nginx`
+  and the `cert-manager.io/cluster-issuer` annotation, fronting the
+  `oauth2-proxy` gateway.
+- Onyxia's region config (`api.regions[].services.expose.certManager`) so that
+  **every service users launch** (Jupyter, RStudio, etc.) gets its own
+  Let's Encrypt certificate without further configuration.
+
+### Google OAuth client
+
+Create a Google OAuth 2.0 Web client for your hostname (e.g. `onyxia.example.com`):
+
+- Authorized JavaScript origin: `https://onyxia.example.com`
+- Authorized redirect URI: `https://onyxia.example.com/oauth2/callback`
+
+The browser-side OAuth runs through the oauth2-proxy gateway, so Onyxia's
+in-browser OpenID Connect mode is not needed and `authentication.mode: none`
+is set in `onyxia-gke-oauth2-proxy-values.yaml`.
+
+### Configure values
+
+Create the local overlay (gitignored):
+
+```bash
+cd helm-chart/examples/gke-ephemeral
+touch onyxia-private-values.local.yaml
+```
+
+Edit `onyxia-private-values.local.yaml`:
+
+```yaml
+ingress:
+  hosts:
+    - host: onyxia.example.com
+
+api:
+  env:
+    security.cors.allowed_origins: "https://onyxia.example.com"
+  regions:
+    - id: gke
+      services:
+        expose:
+          domain: services.onyxia.example.com
+          certManager:
+            useCertManager: true
+            certManagerClusterIssuer: letsencrypt-prod
+```
+
+The OAuth client secret and cookie secret are passed via a Kubernetes Secret
+referenced by `oauth2_proxy_secret_name`. Create it out of band so secrets do
+not enter Terraform state:
+
+```bash
+kubectl -n onyxia create secret generic onyxia-oauth2-proxy \
+  --from-file=client-secret=/path/to/client-secret \
+  --from-file=cookie-secret=/path/to/cookie-secret
+```
+
+### Enable public mode in tfvars
+
+In `terraform/app/terraform.tfvars`:
+
+```hcl
+public_hostname                  = "onyxia.example.com"
+extra_values_files = [
+  "../../onyxia-gke-public-values.yaml",
+  "../../onyxia-gke-oauth2-proxy-values.yaml",
+  "../../onyxia-private-values.local.yaml",
+]
+
+enable_oauth2_proxy_gateway = true
+oauth2_proxy_client_id      = "000000000000-example.apps.googleusercontent.com"
+oauth2_proxy_allowed_emails = ["me@example.com"]
+oauth2_proxy_secret_name    = "onyxia-oauth2-proxy"
+oauth2_proxy_cookie_domain  = ".onyxia.example.com"
+oauth2_proxy_whitelist_domains = [".onyxia.example.com"]
+
+enable_services_ingress_nginx      = true
+services_ingress_class_name        = "nginx"
+services_ingress_nginx_oauth2_auth = true
+
+enable_cert_manager              = true
+cert_manager_letsencrypt_email   = "me@example.com"
+cert_manager_cluster_issuer_name = "letsencrypt-prod"
+
+# Legacy GCE/ManagedCertificate path. Leave false — kept only for users who
+# can't use cert-manager / Let's Encrypt and want Google-managed certificates.
+create_gke_public_ingress_support = false
+```
+
+### Apply and point DNS
+
+```bash
+cd terraform/app
+tofu apply
+```
+
+Take the load balancer IP from the apply outputs:
+
+```bash
+tofu output -raw services_ingress_nginx_ip
+```
+
+Create two DNS records at your provider (Cloudflare, OVH, Route53, etc.):
+
+```
+A   onyxia.example.com               <services_ingress_nginx_ip>
+A   *.services.onyxia.example.com    <services_ingress_nginx_ip>
+```
+
+Use a short TTL (300s) while iterating.
+
+Once the records resolve to the LB, cert-manager will satisfy the HTTP-01
+challenge in under a minute. Check progress:
+
+```bash
+kubectl -n onyxia get certificate,order,challenge
+```
+
+When the certificate is `Ready=True`, open `https://onyxia.example.com`.
+
+### Validate end-to-end
+
+A quick smoke test of the cert-manager / ingress-nginx pipeline, without going
+through Onyxia, uses any host in the services wildcard:
+
+```bash
+kubectl create namespace cert-smoketest
+kubectl -n cert-smoketest apply -f - <<'EOF'
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hello
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts: [cert-smoketest.services.onyxia.example.com]
+    secretName: cert-smoketest-tls
+  rules:
+  - host: cert-smoketest.services.onyxia.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kubernetes  # any service; auth will block the response anyway
+            port:
+              number: 443
+EOF
+kubectl -n cert-smoketest get certificate -w
+kubectl delete namespace cert-smoketest
+```
+
+On a healthy setup the certificate becomes `Ready=True` in 10–30 seconds.
+
+## GKE Autopilot Gotchas
+
+GKE Autopilot is a great fit for ephemeral test clusters, but enforces a few
+Pod Security / namespace constraints that bite generic Helm charts. The
+example's `terraform/app/main.tf` already works around the following:
+
+- **`kube-system` is read-only for workloads.** cert-manager's controller and
+  cainjector default to leader-election leases in `kube-system`. The example
+  pins `global.leaderElection.namespace=<cert-manager namespace>`.
+- **`cert-manager-startupapicheck` job is flaky on Autopilot.** It's a
+  post-install health check, not a runtime dependency. The example disables it
+  via `startupapicheck.enabled=false`.
+- **cert-manager 1.16+ ships `crds.enabled`.** The deprecated `installCRDs`
+  flag conflicts with it. The example only sets `crds.enabled=true`.
+- **No write access to the `gce-pd` storage class metadata.** Standard PVCs
+  still work; just don't try to mutate the default storage class.
+
+## Pause And Resume
+
+Destroy the disposable layers:
+
+```bash
+PROJECT_ID=my-gcp-project ./scripts/down.sh         # app only
+PROJECT_ID=my-gcp-project ./scripts/down.sh --full  # app + cluster + VPC
+```
+
+The backup bucket from `terraform/base` remains.
+
+Resume by re-running `./scripts/up.sh` (the script will re-apply
+`terraform/cluster` and `terraform/app` in order if needed).
+
+Sanity-check that no LBs, forwarding rules, or reserved IPs are left behind:
+
+```bash
+gcloud compute forwarding-rules list --project my-gcp-project
+gcloud compute addresses list        --project my-gcp-project
+gcloud compute target-https-proxies list --project my-gcp-project
+gcloud container clusters list       --project my-gcp-project
+```
+
+## Layout
+
+```
+helm-chart/examples/gke-ephemeral/
+├── README.md
+├── onyxia-values.yaml                       # minimal local-only values
+├── onyxia-gke-public-values.yaml            # public mode values (committed)
+├── onyxia-gke-oauth2-proxy-values.yaml      # oauth2-proxy gateway values (committed)
+├── onyxia-private-values.local.yaml         # gitignored, your specifics
+├── scripts/
+│   ├── bootstrap.sh                          # install prerequisites (idempotent)
+│   ├── up.sh / down.sh / status.sh           # day-to-day lifecycle
+│   ├── common.sh                             # shared helpers
+│   └── onyxia-local-proxy.mjs                # /api routing for local mode
+└── terraform/
+    ├── base/      # backup bucket
+    ├── cluster/   # GKE Autopilot + VPC
+    └── app/       # Onyxia + ingress-nginx + cert-manager
+```

--- a/helm-chart/examples/gke-ephemeral/onyxia-gke-oauth2-proxy-values.yaml
+++ b/helm-chart/examples/gke-ephemeral/onyxia-gke-oauth2-proxy-values.yaml
@@ -1,0 +1,49 @@
+# GKE public test values for the optional oauth2-proxy gateway.
+#
+# The gateway performs Google OAuth before traffic reaches Onyxia. Onyxia itself
+# runs without its browser-side OpenID Connect flow because Google web clients
+# require a client secret at the token endpoint.
+
+api:
+  serviceAccount:
+    clusterAdmin: true
+  env:
+    authentication.mode: none
+    security.cors.allowed_origins: "https://onyxia.example.com"
+  regions:
+    - id: gke
+      name: GKE test
+      description: Short-lived GKE Autopilot test region.
+      onyxiaAPI:
+        baseURL: ""
+      services:
+        type: KUBERNETES
+        expose:
+          domain: services.onyxia.example.com
+          ingressClassName: nginx
+          ingress: true
+          route: false
+          certManager:
+            useCertManager: true
+            certManagerClusterIssuer: letsencrypt-prod
+        singleNamespace: false
+        userNamespace: true
+        namespacePrefix: user-
+        usernamePrefix: user-
+        groupNamespacePrefix: project-
+        authenticationMode: serviceAccount
+        namespaceAnnotationsDynamic:
+          enabled: false
+        quotas:
+          userEnabled: true
+          user:
+            requests.memory: 4Gi
+            requests.cpu: "2"
+            limits.memory: 8Gi
+            limits.cpu: "4"
+            requests.storage: 20Gi
+            count/pods: "10"
+          groupEnabled: false
+      data: {}
+      auth:
+        type: none

--- a/helm-chart/examples/gke-ephemeral/onyxia-gke-public-values.yaml
+++ b/helm-chart/examples/gke-ephemeral/onyxia-gke-public-values.yaml
@@ -1,19 +1,35 @@
-# With enable_oauth2_proxy_gateway=true, the public ingress for Onyxia is
-# managed by Terraform (auth_gateway_ingress), so the chart's own Ingress is
-# disabled here. Set ingress.enabled=true (and remove the gateway) if you want
-# Onyxia exposed directly.
+# Public mode with Keycloak as IdP (Google identity provider configured in Keycloak).
 ingress:
-  enabled: false
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/enable-global-auth: "false"
+    # Override the strict CSP shipped by onyxia-web so the browser can iframe
+    # the Keycloak login flow (which itself iframes accounts.google.com during
+    # the broker callback) without being blocked.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Content-Security-Policy: frame-src https: data:; frame-ancestors 'self'; worker-src 'self' blob:; object-src 'none'";
+  hosts:
+    - host: onyxia.example.com
+  tls:
+    - hosts:
+        - onyxia.example.com
+      secretName: onyxia-core-tls
 
 api:
   serviceAccount:
     clusterAdmin: true
   env:
     authentication.mode: openidconnect
-    oidc.issuer-uri: "https://accounts.google.com"
+    oidc.issuer-uri: "https://auth.example.com/realms/onyxia"
+    oidc.clientID: "onyxia"
+    # Must produce an RFC1123-compliant token (no dots/@). 'sub' is the
+    # Keycloak UUID and always works. 'email' would break the user-project
+    # because Onyxia API filters non-RFC1123 namespaces.
     oidc.username-claim: sub
     oidc.scope: "openid profile email"
-    oidc.extra-query-params: prompt=select_account
     security.cors.allowed_origins: "https://onyxia.example.com"
   regions:
     - id: gke

--- a/helm-chart/examples/gke-ephemeral/onyxia-gke-public-values.yaml
+++ b/helm-chart/examples/gke-ephemeral/onyxia-gke-public-values.yaml
@@ -1,0 +1,76 @@
+# With enable_oauth2_proxy_gateway=true, the public ingress for Onyxia is
+# managed by Terraform (auth_gateway_ingress), so the chart's own Ingress is
+# disabled here. Set ingress.enabled=true (and remove the gateway) if you want
+# Onyxia exposed directly.
+ingress:
+  enabled: false
+
+api:
+  serviceAccount:
+    clusterAdmin: true
+  env:
+    authentication.mode: openidconnect
+    oidc.issuer-uri: "https://accounts.google.com"
+    oidc.username-claim: sub
+    oidc.scope: "openid profile email"
+    oidc.extra-query-params: prompt=select_account
+    security.cors.allowed_origins: "https://onyxia.example.com"
+  regions:
+    - id: gke
+      name: GKE test
+      description: Short-lived GKE Autopilot test region.
+      onyxiaAPI:
+        baseURL: ""
+      services:
+        type: KUBERNETES
+        expose:
+          domain: services.onyxia.example.com
+          ingressClassName: nginx
+          ingress: true
+          route: false
+          certManager:
+            useCertManager: true
+            certManagerClusterIssuer: letsencrypt-prod
+        singleNamespace: false
+        userNamespace: true
+        namespacePrefix: user-
+        usernamePrefix: oidc-
+        groupNamespacePrefix: project-
+        authenticationMode: serviceAccount
+        namespaceAnnotationsDynamic:
+          enabled: true
+          userAttributes:
+            - sub
+            - email
+        quotas:
+          userEnabled: true
+          user:
+            requests.memory: 4Gi
+            requests.cpu: "2"
+            limits.memory: 8Gi
+            limits.cpu: "4"
+            requests.storage: 20Gi
+            count/pods: "10"
+          groupEnabled: false
+      data: {}
+      auth:
+        type: openidconnect
+  catalogs:
+    - id: ide
+      name:
+        en: Development environments
+        fr: Environnements de développement
+      maintainer: innovation@insee.fr
+      location: https://inseefrlab.github.io/helm-charts-interactive-services
+      status: PROD
+      highlightedCharts:
+        - jupyter-python
+        - rstudio
+        - vscode-python
+      type: helm
+      skipTlsVerify: false
+      allowSharing: false
+      visible:
+        user: true
+        project: false
+      multipleServicesMode: latest

--- a/helm-chart/examples/gke-ephemeral/onyxia-values.yaml
+++ b/helm-chart/examples/gke-ephemeral/onyxia-values.yaml
@@ -1,0 +1,41 @@
+# Minimal GKE test values for a short-lived Onyxia deployment.
+#
+# This intentionally avoids any public exposure by default. Use the local proxy
+# from this example for the first test run, then add Ingress/Gateway API values
+# only if you need a public endpoint.
+
+ingress:
+  enabled: false
+
+httpRoute:
+  enabled: false
+
+route:
+  enabled: false
+
+web:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  startupProbe:
+    enabled: true
+    failureThreshold: 30
+
+api:
+  replicaCount: 1
+  env:
+    authentication.mode: none
+  serviceAccount:
+    clusterAdmin: false
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+  startupProbe:
+    enabled: true
+    failureThreshold: 30
+
+onboarding:
+  enabled: false

--- a/helm-chart/examples/gke-ephemeral/scripts/bootstrap.sh
+++ b/helm-chart/examples/gke-ephemeral/scripts/bootstrap.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Install the prerequisites needed to run the gke-ephemeral example.
+#
+# Idempotent. Safe to re-run. User-local where possible.
+#   - OpenTofu          -> ~/.local/bin/tofu                       (no sudo)
+#   - gke-gcloud-auth-plugin -> system package via apt + Google repo (sudo)
+#
+# Override versions via env: TOFU_VERSION=1.11.7 ./bootstrap.sh
+set -euo pipefail
+
+TOFU_VERSION="${TOFU_VERSION:-1.11.7}"
+OS_ARCH="linux_amd64"
+BIN_DIR="${HOME}/.local/bin"
+
+log()  { printf '\033[0;36m[bootstrap]\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m[bootstrap]\033[0m %s\n' "$*" >&2; }
+err()  { printf '\033[0;31m[bootstrap]\033[0m %s\n' "$*" >&2; }
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    err "Required base tool '$1' is missing. Install it then re-run."
+    exit 1
+  fi
+}
+
+ensure_user_bin_on_path() {
+  mkdir -p "${BIN_DIR}"
+  case ":${PATH}:" in
+    *":${BIN_DIR}:"*) ;;
+    *) warn "${BIN_DIR} is not on PATH. Add this to your shell rc: export PATH=\"\$HOME/.local/bin:\$PATH\"" ;;
+  esac
+}
+
+install_tofu() {
+  if command -v tofu >/dev/null 2>&1 && tofu --version 2>/dev/null | grep -q "v${TOFU_VERSION}"; then
+    log "OpenTofu v${TOFU_VERSION} already installed: $(command -v tofu)"
+    return
+  fi
+  log "Installing OpenTofu v${TOFU_VERSION} to ${BIN_DIR}/tofu"
+  local url="https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_${OS_ARCH}.tar.gz"
+  local tmp
+  tmp="$(mktemp -d)"
+  trap "rm -rf '${tmp}'" RETURN
+  curl -fsSL "${url}" -o "${tmp}/tofu.tgz"
+  tar -xzf "${tmp}/tofu.tgz" -C "${tmp}" tofu
+  install -m 0755 "${tmp}/tofu" "${BIN_DIR}/tofu"
+  log "OpenTofu installed: $("${BIN_DIR}/tofu" --version | head -1)"
+}
+
+install_gke_auth_plugin() {
+  if command -v gke-gcloud-auth-plugin >/dev/null 2>&1; then
+    log "gke-gcloud-auth-plugin already installed: $(command -v gke-gcloud-auth-plugin)"
+    return
+  fi
+  log "Installing gke-gcloud-auth-plugin via Google Cloud apt repo (sudo required once)"
+  if ! command -v sudo >/dev/null 2>&1; then
+    err "sudo is required to install the apt package. Aborting."
+    exit 1
+  fi
+  local keyring="/usr/share/keyrings/cloud.google.gpg"
+  local listfile="/etc/apt/sources.list.d/google-cloud-sdk.list"
+  if [ ! -s "${keyring}" ]; then
+    log "Adding Google Cloud apt signing key"
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | sudo gpg --dearmor -o "${keyring}"
+  fi
+  if [ ! -f "${listfile}" ] || ! grep -q "cloud-sdk" "${listfile}"; then
+    log "Adding Google Cloud apt repo to ${listfile}"
+    echo "deb [signed-by=${keyring}] https://packages.cloud.google.com/apt cloud-sdk main" \
+      | sudo tee "${listfile}" >/dev/null
+  fi
+  sudo apt-get update -qq
+  sudo apt-get install -y --no-install-recommends google-cloud-cli-gke-gcloud-auth-plugin
+  log "gke-gcloud-auth-plugin installed: $(command -v gke-gcloud-auth-plugin)"
+}
+
+main() {
+  require_tool curl
+  require_tool tar
+  require_tool gcloud
+  require_tool kubectl
+  require_tool helm
+
+  ensure_user_bin_on_path
+  install_tofu
+  install_gke_auth_plugin
+
+  log "Versions:"
+  printf '  tofu                     %s\n' "$(tofu --version | head -1)"
+  printf '  gke-gcloud-auth-plugin   %s\n' "$(gke-gcloud-auth-plugin --version 2>/dev/null | head -1 || echo '(ok)')"
+  printf '  gcloud                   %s\n' "$(gcloud --version | head -1)"
+  printf '  kubectl                  %s\n' "$(kubectl version --client=true 2>/dev/null | head -1)"
+  printf '  helm                     %s\n' "$(helm version --short)"
+  log "Bootstrap complete."
+}
+
+main "$@"

--- a/helm-chart/examples/gke-ephemeral/scripts/common.sh
+++ b/helm-chart/examples/gke-ephemeral/scripts/common.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Shared helpers for up.sh / down.sh / status.sh.
+# Sourced, not executed directly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TF_APP_DIR="${EXAMPLE_DIR}/terraform/app"
+
+PROJECT_ID="${PROJECT_ID:-}"
+LOCATION="${LOCATION:-us-central1}"
+CLUSTER_NAME="${CLUSTER_NAME:-onyxia-test}"
+
+color() { printf '\033[0;%sm%s\033[0m\n' "$1" "$2"; }
+log()   { color 36 "[$(basename "$0")] $*"; }
+warn()  { color 33 "[$(basename "$0")] WARN: $*" >&2; }
+err()   { color 31 "[$(basename "$0")] ERROR: $*" >&2; }
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    err "missing required tool: $1 (run ./scripts/bootstrap.sh first)"
+    exit 1
+  fi
+}
+
+require_project() {
+  if [ -z "${PROJECT_ID}" ]; then
+    err "PROJECT_ID is not set. Export it or pass it inline: PROJECT_ID=my-gcp-project ./scripts/$(basename "$0")"
+    exit 1
+  fi
+}
+
+kube_ctx_for_cluster() {
+  require_tool gcloud
+  require_tool kubectl
+  gcloud container clusters get-credentials "${CLUSTER_NAME}" \
+    --project "${PROJECT_ID}" \
+    --location "${LOCATION}" >/dev/null 2>&1
+}

--- a/helm-chart/examples/gke-ephemeral/scripts/down.sh
+++ b/helm-chart/examples/gke-ephemeral/scripts/down.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Tear the gke-ephemeral example down.
+#
+# Default scope: the app layer only (Onyxia + ingress-nginx + cert-manager,
+# the two LBs and the Onyxia ingress). The cluster, VPC and bootstrap state
+# stay up. Use --full to also destroy the cluster and VPC.
+#
+# Usage:
+#   PROJECT_ID=my-gcp-project ./scripts/down.sh         # destroy app layer
+#   PROJECT_ID=my-gcp-project ./scripts/down.sh --full  # destroy everything
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_project
+require_tool tofu
+
+FULL=0
+for arg in "$@"; do
+  case "$arg" in
+    --full) FULL=1 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20
+      exit 0
+      ;;
+    *) err "unknown arg: $arg"; exit 2 ;;
+  esac
+done
+
+log "tofu destroy app layer"
+( cd "${TF_APP_DIR}" && tofu destroy -input=false -auto-approve )
+
+if [ "${FULL}" -eq 1 ]; then
+  for layer in cluster base; do
+    dir="${EXAMPLE_DIR}/terraform/${layer}"
+    if [ -d "${dir}" ]; then
+      log "tofu destroy ${layer} layer"
+      ( cd "${dir}" && tofu destroy -input=false -auto-approve )
+    fi
+  done
+fi
+
+log "down complete."

--- a/helm-chart/examples/gke-ephemeral/scripts/keycloak-init.sh
+++ b/helm-chart/examples/gke-ephemeral/scripts/keycloak-init.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Configure a Keycloak realm `onyxia` with a public PKCE client and a Google
+# identity provider. Idempotent (safe to re-run). With the chart's default
+# H2 in-memory database, run after every Keycloak restart.
+#
+# Required env:
+#   KC_ADMIN_PASSWORD     Keycloak `admin` bootstrap password (from tfvars).
+#   GOOGLE_CLIENT_ID      Google OAuth Web client ID.
+#   GOOGLE_CLIENT_SECRET  Google OAuth Web client secret (or set
+#                         ONYXIA_OAUTH2_SECRET_NAME to read it from the
+#                         Kubernetes Secret created for oauth2-proxy).
+#   ONYXIA_HOSTNAME       Public hostname Onyxia is served on (e.g.
+#                         onyxia.example.com).
+#   KEYCLOAK_HOSTNAME     Public hostname Keycloak is served on (e.g.
+#                         auth.onyxia.example.com).
+#
+# Optional env:
+#   KEYCLOAK_NAMESPACE    Default: keycloak
+#   KEYCLOAK_POD          Default: keycloak-keycloakx-0
+set -euo pipefail
+
+KEYCLOAK_NAMESPACE="${KEYCLOAK_NAMESPACE:-keycloak}"
+KEYCLOAK_POD="${KEYCLOAK_POD:-keycloak-keycloakx-0}"
+ONYXIA_OAUTH2_SECRET_NAME="${ONYXIA_OAUTH2_SECRET_NAME:-onyxia-oauth2-proxy}"
+
+err() { echo "ERROR: $*" >&2; exit 2; }
+
+[ -n "${KC_ADMIN_PASSWORD:-}" ] || err "set KC_ADMIN_PASSWORD"
+[ -n "${GOOGLE_CLIENT_ID:-}" ]  || err "set GOOGLE_CLIENT_ID"
+[ -n "${ONYXIA_HOSTNAME:-}" ]   || err "set ONYXIA_HOSTNAME (e.g. onyxia.example.com)"
+[ -n "${KEYCLOAK_HOSTNAME:-}" ] || err "set KEYCLOAK_HOSTNAME (e.g. auth.onyxia.example.com)"
+
+if [ -z "${GOOGLE_CLIENT_SECRET:-}" ]; then
+  GOOGLE_CLIENT_SECRET="$(kubectl -n onyxia get secret "${ONYXIA_OAUTH2_SECRET_NAME}" -o jsonpath='{.data.client-secret}' 2>/dev/null | base64 -d)" \
+    || err "set GOOGLE_CLIENT_SECRET or create Secret '${ONYXIA_OAUTH2_SECRET_NAME}' in ns 'onyxia' with key client-secret"
+fi
+
+KCADM=(kubectl -n "$KEYCLOAK_NAMESPACE" exec "$KEYCLOAK_POD" -- /opt/keycloak/bin/kcadm.sh)
+SERVER=http://localhost:8080
+
+echo "[init-kc] waiting for pod ${KEYCLOAK_NAMESPACE}/${KEYCLOAK_POD} ready..."
+until [ "$(kubectl -n "$KEYCLOAK_NAMESPACE" get pod "$KEYCLOAK_POD" -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null)" = "true" ]; do
+  sleep 5
+done
+
+echo "[init-kc] login as admin on master realm..."
+"${KCADM[@]}" config credentials --server "$SERVER" --realm master --user admin --password "$KC_ADMIN_PASSWORD"
+
+echo "[init-kc] create realm onyxia (idempotent)..."
+"${KCADM[@]}" get realms/onyxia >/dev/null 2>&1 \
+  || "${KCADM[@]}" create realms -s realm=onyxia -s enabled=true
+
+echo "[init-kc] create client onyxia (public, PKCE) (idempotent)..."
+"${KCADM[@]}" get clients -r onyxia --query clientId=onyxia 2>/dev/null | grep -q '"clientId" : "onyxia"' \
+  || "${KCADM[@]}" create clients -r onyxia \
+      -s clientId=onyxia -s publicClient=true -s standardFlowEnabled=true -s directAccessGrantsEnabled=false \
+      -s "redirectUris=[\"https://${ONYXIA_HOSTNAME}/*\"]" \
+      -s "webOrigins=[\"https://${ONYXIA_HOSTNAME}\"]" \
+      -s 'attributes."pkce.code.challenge.method"=S256'
+
+echo "[init-kc] create Google identity provider (idempotent)..."
+"${KCADM[@]}" get identity-provider/instances/google -r onyxia >/dev/null 2>&1 \
+  || "${KCADM[@]}" create identity-provider/instances -r onyxia \
+      -s alias=google -s providerId=google -s enabled=true -s trustEmail=true \
+      -s "config.clientId=$GOOGLE_CLIENT_ID" \
+      -s "config.clientSecret=$GOOGLE_CLIENT_SECRET" \
+      -s 'config.useJwksUrl=true'
+
+echo "[init-kc] done. Discovery doc:"
+curl -s --max-time 10 "https://${KEYCLOAK_HOSTNAME}/realms/onyxia/.well-known/openid-configuration" \
+  | head -c 200 || true
+echo

--- a/helm-chart/examples/gke-ephemeral/scripts/onyxia-local-proxy.mjs
+++ b/helm-chart/examples/gke-ephemeral/scripts/onyxia-local-proxy.mjs
@@ -1,0 +1,69 @@
+import http from "node:http";
+
+function readPort(name, defaultValue) {
+  const value = process.env[name] ?? defaultValue;
+  const port = Number(value);
+
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`${name} must be a TCP port, got ${JSON.stringify(value)}`);
+  }
+
+  return port;
+}
+
+const listenPort = readPort("ONYXIA_PROXY_PORT", "18080");
+const webPort = readPort("ONYXIA_WEB_PORT", "18082");
+const apiPort = readPort("ONYXIA_API_PORT", "18083");
+const onboardingPort =
+  process.env.ONYXIA_ONBOARDING_PORT === undefined
+    ? undefined
+    : readPort("ONYXIA_ONBOARDING_PORT");
+
+const server = http.createServer((clientReq, clientRes) => {
+  const path = clientReq.url ?? "/";
+  const isOnboarding =
+    path === "/api/onboarding" || path.startsWith("/api/onboarding/");
+  const isApi = path === "/api" || path.startsWith("/api/");
+  const targetPort =
+    onboardingPort !== undefined && isOnboarding
+      ? onboardingPort
+      : isApi
+        ? apiPort
+        : webPort;
+
+  const upstreamReq = http.request(
+    {
+      hostname: "127.0.0.1",
+      port: targetPort,
+      method: clientReq.method,
+      path,
+      headers: clientReq.headers
+    },
+    upstreamRes => {
+      clientRes.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+      upstreamRes.pipe(clientRes);
+    }
+  );
+
+  upstreamReq.on("error", error => {
+    clientRes.writeHead(502, { "content-type": "text/plain" });
+    clientRes.end(`Proxy upstream error: ${error.message}\n`);
+  });
+
+  clientReq.pipe(upstreamReq);
+});
+
+server.listen(listenPort, "127.0.0.1", () => {
+  console.log(
+    [
+      `Onyxia local proxy: http://127.0.0.1:${listenPort}`,
+      `/ -> 127.0.0.1:${webPort}`,
+      `/api -> 127.0.0.1:${apiPort}`,
+      onboardingPort === undefined
+        ? undefined
+        : `/api/onboarding -> 127.0.0.1:${onboardingPort}`
+    ]
+      .filter(Boolean)
+      .join(", ")
+  );
+});

--- a/helm-chart/examples/gke-ephemeral/scripts/status.sh
+++ b/helm-chart/examples/gke-ephemeral/scripts/status.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Show the current state of the gke-ephemeral deployment.
+# Read-only. Safe to run any time.
+#
+# Usage:
+#   PROJECT_ID=my-gcp-project ./scripts/status.sh
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_project
+require_tool gcloud
+require_tool kubectl
+require_tool helm
+
+log "gcloud project: ${PROJECT_ID}  location: ${LOCATION}  cluster: ${CLUSTER_NAME}"
+kube_ctx_for_cluster
+
+log "nodes"
+kubectl get nodes -o wide --no-headers 2>/dev/null | awk '{print "  "$1, $2, $3, $5}' || true
+
+log "helm releases"
+helm list -A | sed 's/^/  /'
+
+log "load balancers (services type=LoadBalancer)"
+kubectl get svc -A --field-selector spec.type=LoadBalancer -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,IP:.status.loadBalancer.ingress[0].ip,PORTS:.spec.ports[*].port' --no-headers 2>/dev/null | sed 's/^/  /' || true
+
+log "ingresses"
+kubectl get ingress -A -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,CLASS:.spec.ingressClassName,HOSTS:.spec.rules[*].host,ADDRESS:.status.loadBalancer.ingress[0].ip' --no-headers 2>/dev/null | sed 's/^/  /' || true
+
+log "certificates"
+kubectl get certificate -A -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status,SECRET:.spec.secretName' --no-headers 2>/dev/null | sed 's/^/  /' || true
+
+log "user-default workloads"
+kubectl -n user-default get pods,svc,ingress 2>/dev/null | sed 's/^/  /' || true
+
+log "cost reminder"
+cat <<EOF
+  - GKE Autopilot control plane: ~\$2.40/d (often covered by GCP free tier).
+  - 1 NLB for the ingress-nginx LoadBalancer:  ~\$0.60/d.
+  - Onyxia core + ingress-nginx + cert-manager pods: ~\$0.70/d.
+  - Idle user services (Jupyter etc.) typically add ~\$1-2/d each.
+  - Shut down user services in the Onyxia UI when you stop working.
+EOF

--- a/helm-chart/examples/gke-ephemeral/scripts/up.sh
+++ b/helm-chart/examples/gke-ephemeral/scripts/up.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Bring the gke-ephemeral example up.
+# Idempotent: re-running it converges to the declared state.
+#
+# Usage:
+#   PROJECT_ID=my-gcp-project ./scripts/up.sh
+#
+# Optional env: LOCATION (default us-central1), CLUSTER_NAME (default onyxia-test).
+# Reads variables from terraform/app/terraform.tfvars (gitignored).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_project
+require_tool tofu
+
+log "tofu init"
+( cd "${TF_APP_DIR}" && tofu init -input=false -upgrade=false )
+
+log "tofu apply"
+( cd "${TF_APP_DIR}" && tofu apply -input=false -auto-approve )
+
+log "configure kubectl context"
+kube_ctx_for_cluster
+
+log "done. helm releases:"
+helm list -A

--- a/helm-chart/examples/gke-ephemeral/terraform/app/main.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/app/main.tf
@@ -59,6 +59,10 @@ locals {
       "no-tls-redirect-locations" = "/.well-known/acme-challenge"
       "ssl-redirect"              = "true"
       "use-forwarded-headers"     = "true"
+      # Allow the Onyxia public Ingress to ship a configuration-snippet that
+      # rewrites CSP (default blocklist forbids `;` which is needed in CSP).
+      "annotation-value-word-blocklist" = ""
+      "annotations-risk-level"          = "Critical"
     },
     var.services_ingress_nginx_oauth2_auth ? {
       "global-auth-response-headers" = "X-Auth-Request-User,X-Auth-Request-Email"
@@ -200,6 +204,10 @@ resource "helm_release" "services_ingress_nginx" {
         }
         replicaCount = 1
         config       = local.services_ingress_nginx_controller_config
+        # Required so the Onyxia public Ingress can ship a configuration-snippet
+        # that rewrites the strict CSP frame-src to allow iframing the IdP login
+        # flow (Keycloak → Google).
+        allowSnippetAnnotations = true
         service = {
           type        = "LoadBalancer"
           annotations = var.services_ingress_nginx_controller_service_annotations
@@ -296,6 +304,132 @@ resource "kubernetes_manifest" "cert_manager_cluster_issuer" {
   }
 
   depends_on = [helm_release.cert_manager, helm_release.services_ingress_nginx]
+}
+
+# ----------------------------------------------------------------------------
+# Optional Keycloak IdP (recommended pattern for Onyxia).
+# A realm + client + Google identity provider are configured separately
+# (admin UI on first run, or a realm import JSON for reproducible deployments).
+# ----------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "keycloak" {
+  count = var.enable_keycloak ? 1 : 0
+
+  metadata {
+    name = var.keycloak_namespace
+
+    labels = {
+      app       = "onyxia"
+      component = "keycloak"
+      example   = "gke-ephemeral"
+    }
+  }
+}
+
+resource "helm_release" "keycloak" {
+  count = var.enable_keycloak ? 1 : 0
+
+  name       = var.keycloak_release_name
+  repository = "https://codecentric.github.io/helm-charts"
+  chart      = "keycloakx"
+  version    = var.keycloak_chart_version
+  namespace  = kubernetes_namespace.keycloak[0].metadata[0].name
+
+  values = [
+    yamlencode({
+      replicas = 1
+      # Drop the chart's /auth path so Onyxia's issuer-uri matches Keycloak's
+      # discovery document at https://<host>/realms/<realm>.
+      http = {
+        relativePath = "/"
+      }
+      # Bootstrap admin via env vars (KC_BOOTSTRAP_ADMIN_*). H2 in-memory db
+      # by default — fine for an ephemeral sandbox; for real deployments
+      # plug an external Postgres via `database.*`.
+      command  = ["/opt/keycloak/bin/kc.sh", "start", "--http-enabled=true", "--proxy-headers=xforwarded", "--hostname-strict=false", "--http-relative-path=/"]
+      extraEnv = <<-EOT
+        - name: KC_BOOTSTRAP_ADMIN_USERNAME
+          value: admin
+        - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+          value: ${var.keycloak_admin_password}
+        - name: KC_HOSTNAME
+          value: https://${var.keycloak_hostname}
+        - name: KC_HTTP_ENABLED
+          value: "true"
+        - name: KC_PROXY_HEADERS
+          value: xforwarded
+      EOT
+      database = {
+        vendor = "dev-mem"
+      }
+      service = {
+        type     = "ClusterIP"
+        httpPort = 80
+      }
+      ingress = { enabled = false }
+      # Autopilot rejects pod anti-affinity below 500m CPU. The chart defaults
+      # apply podAntiAffinity, so we bump CPU rather than override the affinity.
+      resources = {
+        requests = { cpu = "500m", memory = "512Mi" }
+        limits   = { memory = "1024Mi" }
+      }
+    })
+  ]
+
+  wait    = true
+  timeout = var.helm_timeout_seconds
+}
+
+resource "kubernetes_manifest" "keycloak_ingress" {
+  count = var.enable_keycloak ? 1 : 0
+
+  manifest = {
+    apiVersion = "networking.k8s.io/v1"
+    kind       = "Ingress"
+    metadata = {
+      name      = var.keycloak_release_name
+      namespace = kubernetes_namespace.keycloak[0].metadata[0].name
+      annotations = {
+        "cert-manager.io/cluster-issuer"                 = var.cert_manager_cluster_issuer_name
+        "nginx.ingress.kubernetes.io/ssl-redirect"       = "true"
+        "nginx.ingress.kubernetes.io/enable-global-auth" = "false"
+        # CORS so oidc-spa on Onyxia can fetch the discovery document.
+        "nginx.ingress.kubernetes.io/enable-cors"        = "true"
+        "nginx.ingress.kubernetes.io/cors-allow-origin"  = "https://${var.public_hostname}"
+        "nginx.ingress.kubernetes.io/cors-allow-methods" = "GET, POST, OPTIONS"
+        "nginx.ingress.kubernetes.io/cors-allow-headers" = "Authorization, Content-Type, Accept, DPoP, dpop"
+      }
+      labels = {
+        "app.kubernetes.io/name"      = "keycloak"
+        "app.kubernetes.io/component" = "idp"
+        "app.kubernetes.io/part-of"   = var.release_name
+      }
+    }
+    spec = {
+      ingressClassName = var.services_ingress_class_name
+      tls = [{
+        hosts      = [var.keycloak_hostname]
+        secretName = "keycloak-tls"
+      }]
+      rules = [{
+        host = var.keycloak_hostname
+        http = {
+          paths = [{
+            path     = "/"
+            pathType = "Prefix"
+            backend = {
+              service = {
+                name = "${var.keycloak_release_name}-keycloakx-http"
+                port = { number = 80 }
+              }
+            }
+          }]
+        }
+      }]
+    }
+  }
+
+  depends_on = [helm_release.keycloak]
 }
 
 resource "helm_release" "onyxia" {

--- a/helm-chart/examples/gke-ephemeral/terraform/app/main.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/app/main.tf
@@ -1,0 +1,751 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.13"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_client_config" "current" {}
+
+data "google_container_cluster" "onyxia" {
+  name     = var.cluster_name
+  project  = var.project_id
+  location = var.region
+}
+
+provider "kubernetes" {
+  host                   = "https://${data.google_container_cluster.onyxia.endpoint}"
+  token                  = data.google_client_config.current.access_token
+  cluster_ca_certificate = base64decode(data.google_container_cluster.onyxia.master_auth[0].cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${data.google_container_cluster.onyxia.endpoint}"
+    token                  = data.google_client_config.current.access_token
+    cluster_ca_certificate = base64decode(data.google_container_cluster.onyxia.master_auth[0].cluster_ca_certificate)
+  }
+}
+
+locals {
+  auth_gateway_name                = "${var.release_name}-auth-gateway"
+  oauth2_proxy_name                = "${var.release_name}-oauth2-proxy"
+  oauth2_proxy_allowed_emails_file = join("\n", concat(var.oauth2_proxy_allowed_emails, [""]))
+  oauth2_proxy_cookie_domain_args  = var.oauth2_proxy_cookie_domain == "" ? [] : ["--cookie-domain=${var.oauth2_proxy_cookie_domain}"]
+  oauth2_proxy_whitelist_domain_args = [
+    for domain in var.oauth2_proxy_whitelist_domains : "--whitelist-domain=${domain}"
+  ]
+  oauth2_proxy_redirect_url = "https://${var.public_hostname}/oauth2/callback"
+  services_ingress_nginx_controller_config = merge(
+    {
+      "force-ssl-redirect"        = "true"
+      "no-tls-redirect-locations" = "/.well-known/acme-challenge"
+      "ssl-redirect"              = "true"
+      "use-forwarded-headers"     = "true"
+    },
+    var.services_ingress_nginx_oauth2_auth ? {
+      "global-auth-response-headers" = "X-Auth-Request-User,X-Auth-Request-Email"
+      "global-auth-signin"           = "https://${var.public_hostname}/oauth2/start?rd=https://$best_http_host$escaped_request_uri"
+      "global-auth-url"              = "http://${local.oauth2_proxy_name}.${var.namespace}.svc.cluster.local/oauth2/auth"
+    } : {}
+  )
+
+  auth_gateway_nginx_config = <<-EOT
+    server {
+      listen 8080;
+      server_name _;
+      server_tokens off;
+
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Uri $request_uri;
+
+      location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+      }
+
+      location /oauth2/ {
+        proxy_pass http://${local.oauth2_proxy_name}.${var.namespace}.svc.cluster.local:80;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Uri $request_uri;
+      }
+
+      location = /oauth2/auth {
+        internal;
+        proxy_pass http://${local.oauth2_proxy_name}.${var.namespace}.svc.cluster.local:80/oauth2/auth;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+      }
+
+      location @oauth2_signin {
+        return 302 https://$host/oauth2/start?rd=https://$host$request_uri;
+      }
+
+      location /api {
+        auth_request /oauth2/auth;
+        error_page 401 = @oauth2_signin;
+        auth_request_set $auth_user $upstream_http_x_auth_request_user;
+        auth_request_set $auth_email $upstream_http_x_auth_request_email;
+        proxy_set_header X-Forwarded-User $auth_user;
+        proxy_set_header X-Forwarded-Email $auth_email;
+        proxy_pass http://${var.release_name}-api.${var.namespace}.svc.cluster.local:80;
+      }
+
+      location / {
+        auth_request /oauth2/auth;
+        error_page 401 = @oauth2_signin;
+        auth_request_set $auth_user $upstream_http_x_auth_request_user;
+        auth_request_set $auth_email $upstream_http_x_auth_request_email;
+        proxy_set_header X-Forwarded-User $auth_user;
+        proxy_set_header X-Forwarded-Email $auth_email;
+        proxy_pass http://${var.release_name}-web.${var.namespace}.svc.cluster.local:80;
+      }
+    }
+  EOT
+}
+
+resource "kubernetes_namespace" "onyxia" {
+  metadata {
+    name = var.namespace
+
+    labels = {
+      app     = "onyxia"
+      example = "gke-ephemeral"
+    }
+  }
+}
+
+resource "google_compute_global_address" "ingress" {
+  count = var.create_gke_public_ingress_support ? 1 : 0
+
+  name         = var.ingress_static_ip_name
+  address_type = "EXTERNAL"
+}
+
+resource "kubernetes_manifest" "managed_certificate" {
+  count = var.create_gke_public_ingress_support ? 1 : 0
+
+  manifest = {
+    apiVersion = "networking.gke.io/v1"
+    kind       = "ManagedCertificate"
+    metadata = {
+      name      = var.managed_certificate_name
+      namespace = kubernetes_namespace.onyxia.metadata[0].name
+    }
+    spec = {
+      domains = [var.public_hostname]
+    }
+  }
+}
+
+resource "kubernetes_namespace" "services_ingress_nginx" {
+  count = var.enable_services_ingress_nginx ? 1 : 0
+
+  metadata {
+    name = var.services_ingress_nginx_namespace
+
+    labels = {
+      app       = "onyxia"
+      component = "services-ingress-nginx"
+      example   = "gke-ephemeral"
+    }
+  }
+}
+
+resource "helm_release" "services_ingress_nginx" {
+  count = var.enable_services_ingress_nginx ? 1 : 0
+
+  name       = var.services_ingress_nginx_release_name
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart      = "ingress-nginx"
+  version    = var.services_ingress_nginx_chart_version
+  namespace  = kubernetes_namespace.services_ingress_nginx[0].metadata[0].name
+
+  values = [
+    yamlencode({
+      controller = {
+        ingressClass = var.services_ingress_class_name
+        ingressClassResource = {
+          controllerValue = "k8s.io/ingress-nginx"
+          default         = false
+          enabled         = true
+          name            = var.services_ingress_class_name
+        }
+        replicaCount = 1
+        config       = local.services_ingress_nginx_controller_config
+        service = {
+          type        = "LoadBalancer"
+          annotations = var.services_ingress_nginx_controller_service_annotations
+        }
+        resources = {
+          requests = {
+            cpu    = "100m"
+            memory = "128Mi"
+          }
+          limits = {
+            memory = "256Mi"
+          }
+        }
+      }
+    })
+  ]
+
+  wait    = true
+  timeout = var.helm_timeout_seconds
+}
+
+resource "kubernetes_namespace" "cert_manager" {
+  count = var.enable_cert_manager ? 1 : 0
+
+  metadata {
+    name = var.cert_manager_namespace
+
+    labels = {
+      app       = "onyxia"
+      component = "cert-manager"
+      example   = "gke-ephemeral"
+    }
+  }
+}
+
+resource "helm_release" "cert_manager" {
+  count = var.enable_cert_manager ? 1 : 0
+
+  name       = var.cert_manager_release_name
+  repository = "https://charts.jetstack.io"
+  chart      = "cert-manager"
+  version    = var.cert_manager_chart_version
+  namespace  = kubernetes_namespace.cert_manager[0].metadata[0].name
+
+  set {
+    name  = "crds.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "startupapicheck.enabled"
+    value = "false"
+  }
+
+  # GKE Autopilot blocks writes to the kube-system namespace, including the
+  # default leader-election leases used by cert-manager. Pin leader election
+  # to the cert-manager namespace so cainjector/controller can start.
+  set {
+    name  = "global.leaderElection.namespace"
+    value = var.cert_manager_namespace
+  }
+
+  wait    = true
+  timeout = var.helm_timeout_seconds
+}
+
+resource "kubernetes_manifest" "cert_manager_cluster_issuer" {
+  count = var.enable_cert_manager && var.cert_manager_letsencrypt_email != "" ? 1 : 0
+
+  manifest = {
+    apiVersion = "cert-manager.io/v1"
+    kind       = "ClusterIssuer"
+    metadata = {
+      name = var.cert_manager_cluster_issuer_name
+    }
+    spec = {
+      acme = {
+        email  = var.cert_manager_letsencrypt_email
+        server = var.cert_manager_acme_server
+        privateKeySecretRef = {
+          name = "${var.cert_manager_cluster_issuer_name}-account-key"
+        }
+        solvers = [
+          {
+            http01 = {
+              ingress = {
+                class = var.services_ingress_class_name
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  depends_on = [helm_release.cert_manager, helm_release.services_ingress_nginx]
+}
+
+resource "helm_release" "onyxia" {
+  name       = var.release_name
+  repository = var.chart_repository
+  chart      = var.chart_name
+  version    = var.chart_version
+  namespace  = kubernetes_namespace.onyxia.metadata[0].name
+
+  values = [for values_file in concat([var.values_file], var.extra_values_files) : file(values_file)]
+
+  wait    = true
+  timeout = var.helm_timeout_seconds
+  depends_on = [
+    google_compute_global_address.ingress,
+    kubernetes_manifest.managed_certificate,
+    kubernetes_manifest.cert_manager_cluster_issuer,
+    helm_release.services_ingress_nginx
+  ]
+}
+
+resource "kubernetes_config_map" "oauth2_proxy_allowed_emails" {
+  count = var.enable_oauth2_proxy_gateway ? 1 : 0
+
+  metadata {
+    name      = "${local.oauth2_proxy_name}-allowed-emails"
+    namespace = kubernetes_namespace.onyxia.metadata[0].name
+
+    labels = {
+      "app.kubernetes.io/name"      = local.oauth2_proxy_name
+      "app.kubernetes.io/component" = "auth"
+      "app.kubernetes.io/part-of"   = var.release_name
+    }
+  }
+
+  data = {
+    "allowed-emails" = local.oauth2_proxy_allowed_emails_file
+  }
+}
+
+resource "kubernetes_manifest" "oauth2_proxy_deployment" {
+  count = var.enable_oauth2_proxy_gateway ? 1 : 0
+
+  manifest = {
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name      = local.oauth2_proxy_name
+      namespace = kubernetes_namespace.onyxia.metadata[0].name
+      labels = {
+        "app.kubernetes.io/name"      = local.oauth2_proxy_name
+        "app.kubernetes.io/component" = "auth"
+        "app.kubernetes.io/part-of"   = var.release_name
+      }
+    }
+    spec = {
+      replicas = 1
+      selector = {
+        matchLabels = {
+          "app.kubernetes.io/name" = local.oauth2_proxy_name
+        }
+      }
+      template = {
+        metadata = {
+          labels = {
+            "app.kubernetes.io/name"      = local.oauth2_proxy_name
+            "app.kubernetes.io/component" = "auth"
+            "app.kubernetes.io/part-of"   = var.release_name
+          }
+        }
+        spec = {
+          containers = [
+            {
+              name  = "oauth2-proxy"
+              image = var.oauth2_proxy_image
+              args = concat(
+                [
+                  "--provider=google",
+                  "--http-address=0.0.0.0:4180",
+                  "--redirect-url=${local.oauth2_proxy_redirect_url}",
+                  "--scope=openid email profile",
+                  "--email-domain=*",
+                  "--authenticated-emails-file=/etc/oauth2-proxy/allowed-emails",
+                  "--cookie-secure=true",
+                  "--cookie-httponly=true",
+                  "--cookie-samesite=lax",
+                  "--cookie-refresh=1h",
+                  "--cookie-expire=8h",
+                  "--set-xauthrequest=true",
+                  "--pass-access-token=false",
+                  "--pass-authorization-header=false",
+                  "--reverse-proxy=true",
+                  "--skip-provider-button=true"
+                ],
+                local.oauth2_proxy_cookie_domain_args,
+                local.oauth2_proxy_whitelist_domain_args,
+                ["--upstream=static://202"]
+              )
+              env = [
+                {
+                  name  = "OAUTH2_PROXY_CLIENT_ID"
+                  value = var.oauth2_proxy_client_id
+                },
+                {
+                  name = "OAUTH2_PROXY_CLIENT_SECRET"
+                  valueFrom = {
+                    secretKeyRef = {
+                      name = var.oauth2_proxy_secret_name
+                      key  = "client-secret"
+                    }
+                  }
+                },
+                {
+                  name = "OAUTH2_PROXY_COOKIE_SECRET"
+                  valueFrom = {
+                    secretKeyRef = {
+                      name = var.oauth2_proxy_secret_name
+                      key  = "cookie-secret"
+                    }
+                  }
+                }
+              ]
+              ports = [
+                {
+                  name          = "http"
+                  containerPort = 4180
+                }
+              ]
+              readinessProbe = {
+                httpGet = {
+                  path = "/ping"
+                  port = "http"
+                }
+              }
+              livenessProbe = {
+                httpGet = {
+                  path = "/ping"
+                  port = "http"
+                }
+              }
+              resources = {
+                requests = {
+                  cpu                 = "50m"
+                  memory              = "64Mi"
+                  "ephemeral-storage" = "64Mi"
+                }
+                limits = {
+                  memory              = "128Mi"
+                  "ephemeral-storage" = "64Mi"
+                }
+              }
+              volumeMounts = [
+                {
+                  name      = "allowed-emails"
+                  mountPath = "/etc/oauth2-proxy"
+                  readOnly  = true
+                }
+              ]
+            }
+          ]
+          volumes = [
+            {
+              name = "allowed-emails"
+              configMap = {
+                name = kubernetes_config_map.oauth2_proxy_allowed_emails[0].metadata[0].name
+                items = [
+                  {
+                    key  = "allowed-emails"
+                    path = "allowed-emails"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  depends_on = [helm_release.onyxia]
+}
+
+resource "kubernetes_manifest" "oauth2_proxy_service" {
+  count = var.enable_oauth2_proxy_gateway ? 1 : 0
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = local.oauth2_proxy_name
+      namespace = kubernetes_namespace.onyxia.metadata[0].name
+      labels = {
+        "app.kubernetes.io/name"      = local.oauth2_proxy_name
+        "app.kubernetes.io/component" = "auth"
+        "app.kubernetes.io/part-of"   = var.release_name
+      }
+    }
+    spec = {
+      type = "ClusterIP"
+      selector = {
+        "app.kubernetes.io/name" = local.oauth2_proxy_name
+      }
+      ports = [
+        {
+          name       = "http"
+          port       = 80
+          targetPort = "http"
+        }
+      ]
+    }
+  }
+
+  depends_on = [kubernetes_manifest.oauth2_proxy_deployment]
+}
+
+resource "kubernetes_config_map" "auth_gateway_nginx" {
+  count = var.enable_oauth2_proxy_gateway ? 1 : 0
+
+  metadata {
+    name      = "${local.auth_gateway_name}-nginx"
+    namespace = kubernetes_namespace.onyxia.metadata[0].name
+
+    labels = {
+      "app.kubernetes.io/name"      = local.auth_gateway_name
+      "app.kubernetes.io/component" = "gateway"
+      "app.kubernetes.io/part-of"   = var.release_name
+    }
+  }
+
+  data = {
+    "default.conf" = local.auth_gateway_nginx_config
+  }
+}
+
+resource "kubernetes_manifest" "auth_gateway_deployment" {
+  count = var.enable_oauth2_proxy_gateway ? 1 : 0
+
+  manifest = {
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name      = local.auth_gateway_name
+      namespace = kubernetes_namespace.onyxia.metadata[0].name
+      labels = {
+        "app.kubernetes.io/name"      = local.auth_gateway_name
+        "app.kubernetes.io/component" = "gateway"
+        "app.kubernetes.io/part-of"   = var.release_name
+      }
+    }
+    spec = {
+      replicas = 1
+      selector = {
+        matchLabels = {
+          "app.kubernetes.io/name" = local.auth_gateway_name
+        }
+      }
+      template = {
+        metadata = {
+          labels = {
+            "app.kubernetes.io/name"      = local.auth_gateway_name
+            "app.kubernetes.io/component" = "gateway"
+            "app.kubernetes.io/part-of"   = var.release_name
+          }
+        }
+        spec = {
+          containers = [
+            {
+              name  = "nginx"
+              image = var.auth_gateway_nginx_image
+              ports = [
+                {
+                  name          = "http"
+                  containerPort = 8080
+                }
+              ]
+              readinessProbe = {
+                httpGet = {
+                  path = "/healthz"
+                  port = "http"
+                }
+              }
+              livenessProbe = {
+                httpGet = {
+                  path = "/healthz"
+                  port = "http"
+                }
+              }
+              resources = {
+                requests = {
+                  cpu                 = "50m"
+                  memory              = "64Mi"
+                  "ephemeral-storage" = "64Mi"
+                }
+                limits = {
+                  memory              = "128Mi"
+                  "ephemeral-storage" = "64Mi"
+                }
+              }
+              volumeMounts = [
+                {
+                  name      = "nginx-config"
+                  mountPath = "/etc/nginx/conf.d"
+                  readOnly  = true
+                }
+              ]
+            }
+          ]
+          volumes = [
+            {
+              name = "nginx-config"
+              configMap = {
+                name = kubernetes_config_map.auth_gateway_nginx[0].metadata[0].name
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  depends_on = [helm_release.onyxia, kubernetes_manifest.oauth2_proxy_service]
+}
+
+resource "kubernetes_manifest" "auth_gateway_backend_config" {
+  count = var.enable_oauth2_proxy_gateway ? 1 : 0
+
+  manifest = {
+    apiVersion = "cloud.google.com/v1"
+    kind       = "BackendConfig"
+    metadata = {
+      name      = local.auth_gateway_name
+      namespace = kubernetes_namespace.onyxia.metadata[0].name
+    }
+    spec = {
+      healthCheck = {
+        type               = "HTTP"
+        requestPath        = "/healthz"
+        port               = 8080
+        checkIntervalSec   = 15
+        timeoutSec         = 5
+        healthyThreshold   = 1
+        unhealthyThreshold = 2
+      }
+    }
+  }
+}
+
+resource "kubernetes_manifest" "auth_gateway_service" {
+  count = var.enable_oauth2_proxy_gateway ? 1 : 0
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = local.auth_gateway_name
+      namespace = kubernetes_namespace.onyxia.metadata[0].name
+      annotations = {
+        "cloud.google.com/backend-config" = jsonencode({ default = local.auth_gateway_name })
+        "cloud.google.com/neg"            = jsonencode({ ingress = true })
+      }
+      labels = {
+        "app.kubernetes.io/name"      = local.auth_gateway_name
+        "app.kubernetes.io/component" = "gateway"
+        "app.kubernetes.io/part-of"   = var.release_name
+      }
+    }
+    spec = {
+      type = "ClusterIP"
+      selector = {
+        "app.kubernetes.io/name" = local.auth_gateway_name
+      }
+      ports = [
+        {
+          name       = "http"
+          port       = 80
+          targetPort = "http"
+        }
+      ]
+    }
+  }
+
+  depends_on = [
+    kubernetes_manifest.auth_gateway_backend_config,
+    kubernetes_manifest.auth_gateway_deployment
+  ]
+}
+
+resource "kubernetes_manifest" "auth_gateway_ingress" {
+  count = var.enable_oauth2_proxy_gateway ? 1 : 0
+
+  manifest = {
+    apiVersion = "networking.k8s.io/v1"
+    kind       = "Ingress"
+    metadata = {
+      name      = var.release_name
+      namespace = kubernetes_namespace.onyxia.metadata[0].name
+      annotations = {
+        "cert-manager.io/cluster-issuer"           = var.cert_manager_cluster_issuer_name
+        "nginx.ingress.kubernetes.io/ssl-redirect" = "true"
+      }
+      labels = {
+        "app.kubernetes.io/name"      = local.auth_gateway_name
+        "app.kubernetes.io/component" = "gateway"
+        "app.kubernetes.io/part-of"   = var.release_name
+      }
+    }
+    spec = {
+      ingressClassName = var.services_ingress_class_name
+      tls = [
+        {
+          hosts      = [var.public_hostname]
+          secretName = "${var.release_name}-tls"
+        }
+      ]
+      defaultBackend = {
+        service = {
+          name = local.auth_gateway_name
+          port = {
+            number = 80
+          }
+        }
+      }
+      rules = [
+        {
+          host = var.public_hostname
+          http = {
+            paths = [
+              {
+                path     = "/"
+                pathType = "Prefix"
+                backend = {
+                  service = {
+                    name = local.auth_gateway_name
+                    port = {
+                      number = 80
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+
+  depends_on = [
+    helm_release.onyxia,
+    kubernetes_manifest.cert_manager_cluster_issuer,
+    kubernetes_manifest.auth_gateway_service,
+    helm_release.services_ingress_nginx
+  ]
+}

--- a/helm-chart/examples/gke-ephemeral/terraform/app/main.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/app/main.tf
@@ -695,6 +695,11 @@ resource "kubernetes_manifest" "auth_gateway_ingress" {
       annotations = {
         "cert-manager.io/cluster-issuer"           = var.cert_manager_cluster_issuer_name
         "nginx.ingress.kubernetes.io/ssl-redirect" = "true"
+        # ingress-nginx is configured cluster-wide with a `global-auth-url`
+        # so that user services inherit the oauth2-proxy auth_request. The
+        # gateway Ingress itself must opt out, otherwise /oauth2/start would
+        # require authentication and the browser loops on ERR_TOO_MANY_REDIRECTS.
+        "nginx.ingress.kubernetes.io/enable-global-auth" = "false"
       }
       labels = {
         "app.kubernetes.io/name"      = local.auth_gateway_name

--- a/helm-chart/examples/gke-ephemeral/terraform/app/outputs.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/app/outputs.tf
@@ -1,0 +1,40 @@
+output "web_port_forward_command" {
+  value       = "kubectl -n ${var.namespace} port-forward --address 127.0.0.1 svc/${var.release_name}-web ${var.local_web_port}:80"
+  description = "Command used to forward the Onyxia web service locally."
+}
+
+output "api_port_forward_command" {
+  value       = "kubectl -n ${var.namespace} port-forward --address 127.0.0.1 svc/${var.release_name}-api ${var.local_api_port}:80"
+  description = "Command used to forward the Onyxia API service locally."
+}
+
+output "local_proxy_command" {
+  value       = "ONYXIA_PROXY_PORT=${var.local_port} ONYXIA_WEB_PORT=${var.local_web_port} ONYXIA_API_PORT=${var.local_api_port} node ../../scripts/onyxia-local-proxy.mjs"
+  description = "Command used from terraform/app to open Onyxia locally with the same /api routing shape as Ingress or HTTPRoute."
+}
+
+output "local_url" {
+  value       = "http://127.0.0.1:${var.local_port}"
+  description = "Local URL after starting both port-forwards and the local proxy."
+}
+
+output "gke_ingress_static_ip" {
+  value       = var.create_gke_public_ingress_support ? google_compute_global_address.ingress[0].address : null
+  description = "Global static IP to point the public DNS record at when GKE public Ingress support is enabled."
+}
+
+data "kubernetes_service" "services_ingress_nginx_controller" {
+  count = var.enable_services_ingress_nginx ? 1 : 0
+
+  metadata {
+    name      = "${var.services_ingress_nginx_release_name}-controller"
+    namespace = var.services_ingress_nginx_namespace
+  }
+
+  depends_on = [helm_release.services_ingress_nginx]
+}
+
+output "services_ingress_nginx_ip" {
+  value       = var.enable_services_ingress_nginx ? try(data.kubernetes_service.services_ingress_nginx_controller[0].status[0].load_balancer[0].ingress[0].ip, null) : null
+  description = "External IP of the optional ingress-nginx controller used by Onyxia user services. Point *.services.<domain> at this IP."
+}

--- a/helm-chart/examples/gke-ephemeral/terraform/app/terraform.tfvars.example
+++ b/helm-chart/examples/gke-ephemeral/terraform/app/terraform.tfvars.example
@@ -1,0 +1,48 @@
+project_id   = "my-gcp-project"
+region       = "us-central1"
+cluster_name = "onyxia-test"
+
+# Hostname Onyxia is published on. Used by ingress-nginx + cert-manager.
+public_hostname    = "onyxia.example.com"
+extra_values_files = []
+
+# Optional Google OAuth gateway for personal or organization-light GKE tests.
+# Recommended for any internet-exposed deployment of this example.
+#
+# Create the matching Kubernetes Secret out of band so OAuth secrets do not
+# enter Terraform state:
+#
+# kubectl -n onyxia create secret generic onyxia-oauth2-proxy \
+#   --from-file=client-secret=/path/to/client-secret \
+#   --from-file=cookie-secret=/path/to/cookie-secret
+enable_oauth2_proxy_gateway = false
+oauth2_proxy_client_id      = ""
+oauth2_proxy_allowed_emails = []
+oauth2_proxy_secret_name    = "onyxia-oauth2-proxy"
+oauth2_proxy_cookie_domain  = ""
+oauth2_proxy_whitelist_domains = []
+
+# Single ingress-nginx controller for Onyxia core and user services.
+# Recommended path: one regional Network LB for everything, instead of one GCE
+# Load Balancer per service.
+enable_services_ingress_nginx      = false
+services_ingress_class_name        = "nginx"
+services_ingress_nginx_oauth2_auth = true
+
+# Automatic TLS via cert-manager + Let's Encrypt. Required for the
+# `services_ingress_nginx` path above to serve trusted HTTPS.
+enable_cert_manager              = false
+cert_manager_letsencrypt_email   = ""
+cert_manager_cluster_issuer_name = "letsencrypt-prod"
+
+# --- Legacy: GCE Ingress + Google-managed certificates -----------------------
+#
+# These switches keep the older path available for environments that cannot use
+# Let's Encrypt / cert-manager (e.g. air-gapped, strict perimeters). When set
+# to true, Terraform reserves a global static IP and creates a GKE
+# `ManagedCertificate`. You must then provide values that publish Onyxia via
+# a GCE-class Ingress; see the README's "Public mode" section for the
+# recommended pattern instead.
+create_gke_public_ingress_support = false
+ingress_static_ip_name            = "onyxia-test-ip"
+managed_certificate_name          = "onyxia-cert"

--- a/helm-chart/examples/gke-ephemeral/terraform/app/terraform.tfvars.example
+++ b/helm-chart/examples/gke-ephemeral/terraform/app/terraform.tfvars.example
@@ -35,6 +35,15 @@ enable_cert_manager              = false
 cert_manager_letsencrypt_email   = ""
 cert_manager_cluster_issuer_name = "letsencrypt-prod"
 
+# Optional in-cluster Keycloak as the OIDC IdP for Onyxia (recommended pattern
+# from SSP Cloud). When enabled, configure the realm afterwards with
+# ./scripts/keycloak-init.sh (Google identity provider, client `onyxia` PKCE).
+# Onyxia talks plain OIDC/PKCE to Keycloak, so the real Gmail identity reaches
+# the platform. Without it, Onyxia would see only the oauth2-proxy mock user.
+enable_keycloak         = false
+keycloak_hostname       = ""                   # e.g. auth.onyxia.example.com — must resolve to the LB
+keycloak_admin_password = "change-me"          # bootstrap Keycloak admin user password
+
 # --- Legacy: GCE Ingress + Google-managed certificates -----------------------
 #
 # These switches keep the older path available for environments that cannot use

--- a/helm-chart/examples/gke-ephemeral/terraform/app/variables.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/app/variables.tf
@@ -229,6 +229,48 @@ variable "cert_manager_letsencrypt_email" {
   }
 }
 
+variable "enable_keycloak" {
+  type        = bool
+  description = "Deploy Keycloak as the OIDC identity provider in front of Onyxia (recommended). Realm + client + Google identity provider are configured separately via the admin UI or a realm import."
+  default     = false
+}
+
+variable "keycloak_namespace" {
+  type        = string
+  description = "Namespace for the Keycloak deployment."
+  default     = "keycloak"
+}
+
+variable "keycloak_release_name" {
+  type        = string
+  description = "Helm release name for Keycloak."
+  default     = "keycloak"
+}
+
+variable "keycloak_chart_version" {
+  type        = string
+  description = "codecentric/keycloakx Helm chart version."
+  default     = "7.1.11"
+}
+
+variable "keycloak_hostname" {
+  type        = string
+  description = "Public hostname Keycloak is served on. Required when enable_keycloak is true. Onyxia's issuer-uri is https://<keycloak_hostname>/realms/<realm>."
+  default     = ""
+
+  validation {
+    condition     = !var.enable_keycloak || var.keycloak_hostname != ""
+    error_message = "keycloak_hostname must be set when enable_keycloak is true."
+  }
+}
+
+variable "keycloak_admin_password" {
+  type        = string
+  description = "Bootstrap admin password for Keycloak (user 'admin')."
+  default     = "admin"
+  sensitive   = true
+}
+
 variable "local_port" {
   type        = number
   description = "Local port used by the local same-origin proxy output."

--- a/helm-chart/examples/gke-ephemeral/terraform/app/variables.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/app/variables.tf
@@ -1,0 +1,248 @@
+variable "project_id" {
+  type        = string
+  description = "Google Cloud project ID."
+}
+
+variable "region" {
+  type        = string
+  description = "GKE Autopilot region."
+  default     = "us-central1"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Disposable GKE cluster name."
+  default     = "onyxia-test"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace for the Onyxia Helm release."
+  default     = "onyxia"
+}
+
+variable "release_name" {
+  type        = string
+  description = "Helm release name."
+  default     = "onyxia"
+}
+
+variable "chart_repository" {
+  type        = string
+  description = "Onyxia Helm chart repository."
+  default     = "https://inseefrlab.github.io/onyxia"
+}
+
+variable "chart_name" {
+  type        = string
+  description = "Onyxia Helm chart name."
+  default     = "onyxia"
+}
+
+variable "chart_version" {
+  type        = string
+  description = "Onyxia Helm chart version."
+  default     = "10.33.0"
+}
+
+variable "values_file" {
+  type        = string
+  description = "Path to the Onyxia Helm values file."
+  default     = "../../onyxia-values.yaml"
+}
+
+variable "extra_values_files" {
+  type        = list(string)
+  description = "Additional Helm values files, applied after values_file. Use ignored local files for deployment-specific OAuth client IDs or hostnames."
+  default     = []
+}
+
+variable "helm_timeout_seconds" {
+  type        = number
+  description = "Timeout for the Onyxia Helm release."
+  default     = 600
+}
+
+variable "create_gke_public_ingress_support" {
+  type        = bool
+  description = "Create GKE-specific public Ingress support resources: a global static IP and a ManagedCertificate."
+  default     = false
+}
+
+variable "public_hostname" {
+  type        = string
+  description = "Public hostname served by the optional GKE ManagedCertificate."
+  default     = ""
+
+  validation {
+    condition     = !var.create_gke_public_ingress_support || var.public_hostname != ""
+    error_message = "public_hostname must be set when create_gke_public_ingress_support is true."
+  }
+}
+
+variable "ingress_static_ip_name" {
+  type        = string
+  description = "Name of the optional global static IP used by the GKE Ingress."
+  default     = "onyxia-test-ip"
+}
+
+variable "managed_certificate_name" {
+  type        = string
+  description = "Name of the optional GKE ManagedCertificate referenced by the Ingress annotations."
+  default     = "onyxia-cert"
+}
+
+variable "enable_oauth2_proxy_gateway" {
+  type        = bool
+  description = "Deploy an optional oauth2-proxy and NGINX gateway in front of Onyxia for Google OAuth on GKE."
+  default     = false
+}
+
+variable "oauth2_proxy_client_id" {
+  type        = string
+  description = "Google OAuth client ID used by the optional oauth2-proxy gateway. The client secret must be provided via an existing Kubernetes Secret."
+  default     = ""
+}
+
+variable "oauth2_proxy_allowed_emails" {
+  type        = list(string)
+  description = "Google account email addresses allowed through the optional oauth2-proxy gateway."
+  default     = []
+}
+
+variable "oauth2_proxy_secret_name" {
+  type        = string
+  description = "Name of the existing Kubernetes Secret containing client-secret and cookie-secret keys for oauth2-proxy."
+  default     = "onyxia-oauth2-proxy"
+}
+
+variable "oauth2_proxy_cookie_domain" {
+  type        = string
+  description = "Optional cookie domain for oauth2-proxy. Use a parent domain such as .example.com when protecting service subdomains."
+  default     = ""
+}
+
+variable "oauth2_proxy_whitelist_domains" {
+  type        = list(string)
+  description = "Optional redirect whitelist domains for oauth2-proxy, for example .example.com when service subdomains redirect through the same OAuth gateway."
+  default     = []
+}
+
+variable "oauth2_proxy_image" {
+  type        = string
+  description = "Container image used for oauth2-proxy."
+  default     = "quay.io/oauth2-proxy/oauth2-proxy:v7.8.1"
+}
+
+variable "auth_gateway_nginx_image" {
+  type        = string
+  description = "Container image used for the optional NGINX auth gateway."
+  default     = "nginx:1.27-alpine"
+}
+
+variable "enable_services_ingress_nginx" {
+  type        = bool
+  description = "Deploy an optional ingress-nginx controller for Onyxia user services to avoid creating one GCE Load Balancer per service Ingress."
+  default     = false
+}
+
+variable "services_ingress_class_name" {
+  type        = string
+  description = "IngressClass name used by Onyxia user services when the optional ingress-nginx controller is enabled."
+  default     = "nginx"
+}
+
+variable "services_ingress_nginx_namespace" {
+  type        = string
+  description = "Namespace for the optional ingress-nginx controller used by Onyxia user services."
+  default     = "ingress-nginx"
+}
+
+variable "services_ingress_nginx_release_name" {
+  type        = string
+  description = "Helm release name for the optional ingress-nginx controller used by Onyxia user services."
+  default     = "ingress-nginx"
+}
+
+variable "services_ingress_nginx_chart_version" {
+  type        = string
+  description = "ingress-nginx Helm chart version."
+  default     = "4.12.1"
+}
+
+variable "services_ingress_nginx_oauth2_auth" {
+  type        = bool
+  description = "Configure ingress-nginx global auth against the optional oauth2-proxy gateway for service subdomains."
+  default     = true
+}
+
+variable "services_ingress_nginx_controller_service_annotations" {
+  type        = map(string)
+  description = "Optional annotations for the ingress-nginx controller LoadBalancer Service."
+  default     = {}
+}
+
+variable "enable_cert_manager" {
+  type        = bool
+  description = "Deploy cert-manager and a Let's Encrypt ClusterIssuer for Onyxia user service TLS."
+  default     = false
+}
+
+variable "cert_manager_namespace" {
+  type        = string
+  description = "Namespace for cert-manager."
+  default     = "cert-manager"
+}
+
+variable "cert_manager_release_name" {
+  type        = string
+  description = "Helm release name for cert-manager."
+  default     = "cert-manager"
+}
+
+variable "cert_manager_chart_version" {
+  type        = string
+  description = "cert-manager Helm chart version."
+  default     = "v1.16.3"
+}
+
+variable "cert_manager_cluster_issuer_name" {
+  type        = string
+  description = "ClusterIssuer name used by Onyxia user service Ingresses."
+  default     = "letsencrypt-prod"
+}
+
+variable "cert_manager_acme_server" {
+  type        = string
+  description = "ACME directory URL used by cert-manager."
+  default     = "https://acme-v02.api.letsencrypt.org/directory"
+}
+
+variable "cert_manager_letsencrypt_email" {
+  type        = string
+  description = "Email address registered with Let's Encrypt. Required when enable_cert_manager is true."
+  default     = ""
+
+  validation {
+    condition     = !var.enable_cert_manager || var.cert_manager_letsencrypt_email != ""
+    error_message = "cert_manager_letsencrypt_email must be set when enable_cert_manager is true."
+  }
+}
+
+variable "local_port" {
+  type        = number
+  description = "Local port used by the local same-origin proxy output."
+  default     = 18080
+}
+
+variable "local_web_port" {
+  type        = number
+  description = "Local port used by the web service port-forward output."
+  default     = 18082
+}
+
+variable "local_api_port" {
+  type        = number
+  description = "Local port used by the API service port-forward output."
+  default     = 18083
+}

--- a/helm-chart/examples/gke-ephemeral/terraform/base/main.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/base/main.tf
@@ -1,0 +1,65 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+locals {
+  labels = {
+    app       = "onyxia"
+    example   = "gke-ephemeral"
+    lifecycle = "durable"
+  }
+
+  bootstrap_services = [
+    "cloudresourcemanager.googleapis.com"
+  ]
+
+  required_services = [
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "storage.googleapis.com"
+  ]
+}
+
+resource "google_project_service" "bootstrap" {
+  for_each = toset(local.bootstrap_services)
+
+  project = var.project_id
+  service = each.value
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "required" {
+  for_each = toset(local.required_services)
+
+  project = var.project_id
+  service = each.value
+
+  disable_on_destroy = false
+
+  depends_on = [google_project_service.bootstrap]
+}
+
+resource "google_storage_bucket" "backup" {
+  name                        = var.backup_bucket_name
+  project                     = var.project_id
+  location                    = var.bucket_location
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  force_destroy               = false
+  labels                      = local.labels
+
+  depends_on = [google_project_service.required]
+}

--- a/helm-chart/examples/gke-ephemeral/terraform/base/outputs.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/base/outputs.tf
@@ -1,0 +1,15 @@
+output "backup_bucket_name" {
+  value       = google_storage_bucket.backup.name
+  description = "Bucket kept across hibernation cycles."
+}
+
+output "backup_bucket_url" {
+  value       = google_storage_bucket.backup.url
+  description = "Google Cloud Storage URL for the hibernation backup bucket."
+}
+
+output "region" {
+  value       = var.region
+  description = "Region used by this example."
+}
+

--- a/helm-chart/examples/gke-ephemeral/terraform/base/terraform.tfvars.example
+++ b/helm-chart/examples/gke-ephemeral/terraform/base/terraform.tfvars.example
@@ -1,0 +1,4 @@
+project_id         = "my-gcp-project"
+region             = "us-central1"
+bucket_location    = "US-CENTRAL1"
+backup_bucket_name = "my-gcp-project-onyxia-test-backup"

--- a/helm-chart/examples/gke-ephemeral/terraform/base/variables.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/base/variables.tf
@@ -1,0 +1,21 @@
+variable "project_id" {
+  type        = string
+  description = "Google Cloud project ID."
+}
+
+variable "region" {
+  type        = string
+  description = "Default Google Cloud region used by this example."
+  default     = "us-central1"
+}
+
+variable "bucket_location" {
+  type        = string
+  description = "Cloud Storage bucket location. Use an uppercase GCS location such as US-CENTRAL1."
+  default     = "US-CENTRAL1"
+}
+
+variable "backup_bucket_name" {
+  type        = string
+  description = "Globally unique Cloud Storage bucket name kept while the cluster is deleted."
+}

--- a/helm-chart/examples/gke-ephemeral/terraform/cluster/main.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/cluster/main.tf
@@ -1,0 +1,69 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+locals {
+  labels = {
+    app       = "onyxia"
+    example   = "gke-ephemeral"
+    lifecycle = "disposable"
+  }
+}
+
+resource "google_compute_network" "onyxia" {
+  name                    = var.network_name
+  project                 = var.project_id
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "onyxia" {
+  name          = var.subnetwork_name
+  project       = var.project_id
+  region        = var.region
+  network       = google_compute_network.onyxia.id
+  ip_cidr_range = var.subnetwork_cidr
+
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = var.pods_cidr
+  }
+
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = var.services_cidr
+  }
+}
+
+resource "google_container_cluster" "onyxia" {
+  name             = var.cluster_name
+  project          = var.project_id
+  location         = var.region
+  enable_autopilot = true
+  network          = google_compute_network.onyxia.id
+  subnetwork       = google_compute_subnetwork.onyxia.id
+
+  deletion_protection = false
+
+  release_channel {
+    channel = "REGULAR"
+  }
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "pods"
+    services_secondary_range_name = "services"
+  }
+
+  resource_labels = local.labels
+}

--- a/helm-chart/examples/gke-ephemeral/terraform/cluster/outputs.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/cluster/outputs.tf
@@ -1,0 +1,22 @@
+output "cluster_name" {
+  value       = google_container_cluster.onyxia.name
+  description = "Disposable GKE cluster name."
+}
+
+output "region" {
+  value       = var.region
+  description = "GKE region."
+}
+
+output "get_credentials_command" {
+  value = join(" ", [
+    "gcloud container clusters get-credentials",
+    google_container_cluster.onyxia.name,
+    "--project",
+    var.project_id,
+    "--location",
+    var.region
+  ])
+  description = "Command used to configure kubectl for the disposable cluster."
+}
+

--- a/helm-chart/examples/gke-ephemeral/terraform/cluster/terraform.tfvars.example
+++ b/helm-chart/examples/gke-ephemeral/terraform/cluster/terraform.tfvars.example
@@ -1,0 +1,3 @@
+project_id   = "my-gcp-project"
+region       = "us-central1"
+cluster_name = "onyxia-test"

--- a/helm-chart/examples/gke-ephemeral/terraform/cluster/variables.tf
+++ b/helm-chart/examples/gke-ephemeral/terraform/cluster/variables.tf
@@ -1,0 +1,46 @@
+variable "project_id" {
+  type        = string
+  description = "Google Cloud project ID."
+}
+
+variable "region" {
+  type        = string
+  description = "GKE Autopilot region."
+  default     = "us-central1"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Disposable GKE cluster name."
+  default     = "onyxia-test"
+}
+
+variable "network_name" {
+  type        = string
+  description = "Disposable VPC network name."
+  default     = "onyxia-test"
+}
+
+variable "subnetwork_name" {
+  type        = string
+  description = "Disposable VPC subnetwork name."
+  default     = "onyxia-test"
+}
+
+variable "subnetwork_cidr" {
+  type        = string
+  description = "Primary CIDR range for the disposable GKE subnetwork."
+  default     = "10.10.0.0/20"
+}
+
+variable "pods_cidr" {
+  type        = string
+  description = "Secondary CIDR range for GKE Pods."
+  default     = "10.20.0.0/16"
+}
+
+variable "services_cidr" {
+  type        = string
+  description = "Secondary CIDR range for Kubernetes Services."
+  default     = "10.30.0.0/20"
+}


### PR DESCRIPTION
## Summary

Adds a new `helm-chart/examples/gke-ephemeral/` example deploying Onyxia on a
short-lived **GKE Autopilot** cluster. The deployment is fully Helm/Kubernetes
on the Onyxia side; cloud-specific glue lives in this example only.

The example covers an end-to-end stack:

- 3 OpenTofu roots (`base` / `cluster` / `app`) for clean hibernation/resume.
- **Single regional Network LB** via ingress-nginx, with cert-manager
  + Let's Encrypt as the recommended TLS path. A flag retains the legacy
  GCE Ingress + Google ManagedCertificate path for environments that can't
  reach Let's Encrypt.
- Onyxia API region config wires `services.expose.certManager` so every
  user service launched from Onyxia is HTTPS Let's Encrypt-valid without
  further configuration.
- Optional **oauth2-proxy gateway** in front of Onyxia core for Google
  OAuth, with `auth_request` integration on ingress-nginx so user services
  inherit the same SSO.
- Idempotent `scripts/bootstrap.sh` installs `tofu` (user-local) and
  `gke-gcloud-auth-plugin` (official Google apt repo).
- `scripts/up.sh` / `down.sh` / `status.sh` for day-to-day lifecycle, with
  inline cost reminders.
- `.helmignore` updated so the `examples/` tree and any Terraform state
  files never ship in the chart package.

## GKE Autopilot footguns documented and fixed in `terraform/app/main.tf`

- Drop the deprecated `installCRDs` Helm value — it conflicts with
  `crds.enabled` in cert-manager 1.16+.
- Disable `cert-manager-startupapicheck` — its post-install Job is flaky on
  Autopilot.
- Pin `global.leaderElection.namespace` off `kube-system` — Autopilot makes
  `kube-system` read-only for workloads, which otherwise breaks
  cainjector / controller startup.

These three workarounds are also documented in the README's "GKE Autopilot
Gotchas" section so future users avoid the same pitfalls.

## Cost profile

Idle target ≈ **~\$3–4/day** (Autopilot control plane + 1 NLB + core pods),
down from ~\$5–6/day with the original two-LB (GCE Ingress + nginx)
arrangement. Adding one running user service typically adds ~\$1–2/day.

After `down.sh --full`, only the small backup bucket from `terraform/base`
remains (well under \$1/month).

The README also shows how to wire a GCP budget alert via
`gcloud billing budgets create` as a safety net.

## Validated end-to-end

- `helm lint helm-chart/` passes.
- `tofu fmt -recursive` clean.
- Deployed on a real \`onyxia-test\` Autopilot cluster.
- `curl -I https://onyxia.<hostname>` returns a 302 to the oauth2-proxy
  login flow over a Let's Encrypt R12-signed certificate (no \`-k\`).
- A user-service smoketest issues a Let's Encrypt cert in ~15 s.

## Test plan

- [ ] Reviewer can spin up a fresh GCP project, run
      `PROJECT_ID=<their project> ./scripts/up.sh` and obtain a working
      Onyxia at `https://onyxia.<their hostname>` after pointing DNS at
      the LB IP.
- [ ] Reviewer can run `./scripts/status.sh` and see the LB + ingress +
      certificate states.
- [ ] Reviewer can launch a Jupyter from the catalog and reach it under
      `https://*.services.onyxia.<their hostname>` with a valid certificate
      out of the box.
- [ ] Reviewer can `./scripts/down.sh --full` and observe that no
      forwarding rules, reserved IPs or clusters remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive GKE Autopilot ephemeral deployment guide covering lifecycle, quickstart, local vs public modes, OAuth2/TLS options, Keycloak path, hibernation/resume, cost notes, and validation steps.

* **New Features**
  * Added a complete ephemeral GKE example: automated provisioning (base/cluster/app), Helm values for local/public modes, runnable scripts for bootstrap/up/status/down, a local HTTP proxy for web/API, and convenient commands/outputs for local port-forwarding and access.

* **Chores**
  * Updated packaging ignores and example gitignore to exclude Terraform/OpenTofu state and local artifacts from chart archives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InseeFrLab/onyxia/pull/1075)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->