### PR TITLE
fix(helm-chart): wrong mount path for onboarding env overrides

### DIFF
--- a/helm-chart/templates/onboarding/deployment.yaml
+++ b/helm-chart/templates/onboarding/deployment.yaml
@@ -79,8 +79,8 @@ spec:
             {{- toYaml .Values.onboarding.resources | nindent 12 }}
           volumeMounts:
             - name: config-volume
-              mountPath: /env.yaml
-              subPath: env.yaml
+              mountPath: /env.onboarding.yaml
+              subPath: env.onboarding.yaml
               readOnly: true
             {{- if .Values.onboarding.extraVolumeMounts }}
             {{ toYaml .Values.onboarding.extraVolumeMounts | nindent 12 }}
@@ -103,7 +103,7 @@ spec:
             name: {{ template "onyxia.onboarding.name" . }}
             items:
               - key: env.yaml
-                path: env.yaml
+                path: env.onboarding.yaml
         {{- if .Values.onboarding.extraVolumes }}
         {{ toYaml .Values.onboarding.extraVolumes | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Commit https://github.com/onyxia-datalab/onyxia-backend/commit/fb2633315345efddf36bd358dab6c2f4e76030c2 changed the path from `env.yaml` to `env.onboarding.yaml` . This caused onboarding not to find the env file and it would fallback to default config. This would result in onboarding giving 4xx errors.

The deployment chart cpuld probably be cleaned up a bit (the config map is mounted as envFrom + volume mount), but this commit is a hot fix which resolves the issue for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the onboarding deployment’s environment configuration file mounting path.
  * Ensured the configuration is available at `/env.onboarding.yaml` as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->